### PR TITLE
Enable Web Audio on Android x86 in Blink

### DIFF
--- a/Source/core/platform/audio/FFTFrame.h
+++ b/Source/core/platform/audio/FFTFrame.h
@@ -45,6 +45,11 @@
 
 #if USE(WEBAUDIO_OPENMAX_DL_FFT)
 #include "dl/sp/api/omxSP.h"
+#if CPU(X86)
+#include "dl/sp/api/x86SP.h"
+#else
+#include "dl/sp/api/armSP.h"
+#endif
 #elif USE(WEBAUDIO_FFMPEG)
 struct RDFTContext;
 #endif

--- a/Source/core/platform/audio/chromium/FFTFrameOpenMAXDLAndroid.cpp
+++ b/Source/core/platform/audio/chromium/FFTFrameOpenMAXDLAndroid.cpp
@@ -32,8 +32,6 @@
 
 #include "core/platform/audio/AudioArray.h"
 #include "core/platform/audio/VectorMath.h"
-#include "dl/sp/api/armSP.h"
-#include "dl/sp/api/omxSP.h"
 
 #include "wtf/MathExtras.h"
 


### PR DESCRIPTION
1. Open the flag of web audio on Android x86.
2. Add x86 header in FFTFrame.h.
3. Remove some useless code.
