### PR TITLE
Do not set zoom: auto to the actual minimum possible scale

### DIFF
--- a/Source/core/page/PageScaleConstraints.cpp
+++ b/Source/core/page/PageScaleConstraints.cpp
@@ -84,10 +84,12 @@ void PageScaleConstraints::fitToContentsWidth(float contentsWidth, int viewWidth
     // width.
     minimumScale = std::max(minimumScale, viewWidthNotIncludingScrollbars / contentsWidth);
 
+    float intendedMinimumScale = std::max(minimumScale, viewWidthNotIncludingScrollbars / layoutSize.width());
+
     // If the initial scale wasn't defined, set it to minimum scale now that we
     // know the real value.
     if (initialScale == -1)
-        initialScale = minimumScale;
+        initialScale = intendedMinimumScale;
 
     clampAll();
 }


### PR DESCRIPTION
But to the one calculated from the intented layout size. The reasoning
is that it might be possible to zoom the page out further that they
layout width in the case components on the page grow beyond this width.

That is an issue as it can cause different scaled when navigating subpages.

https://code.google.com/p/chromium/issues/detail?id=326149
