### PR TITLE
[Remove after rebase] Do not consider resizes to be orientation changes

### DIFF
--- a/Source/web/WebViewImpl.cpp
+++ b/Source/web/WebViewImpl.cpp
@@ -1697,7 +1697,16 @@ void WebViewImpl::resize(const WebSize& newSize)
 
     m_size = newSize;
 
-    bool shouldAnchorAndRescaleViewport = settings()->viewportEnabled() && oldSize.width && oldContentsWidth && newSize.width != oldSize.width;
+    // FIXME: Remove and set setting instead when rebasing:
+#if defined(OS_TIZEN)
+    bool mainFrameResizesAreOrientationChanges = true;
+#else
+    bool mainFrameResizesAreOrientationChanges = false;
+#endif
+
+    bool shouldAnchorAndRescaleViewport = mainFrameResizesAreOrientationChanges
+        && oldSize.width && oldContentsWidth && newSize.width != oldSize.width;
+
     ViewportAnchor viewportAnchor(&mainFrameImpl()->frame()->eventHandler());
     if (shouldAnchorAndRescaleViewport) {
         viewportAnchor.setAnchor(view->visibleContentRect(),


### PR DESCRIPTION
This is a workaround instead of having to cherrypick all the viewport
on desktop patches. This can be removed after rebase and a setting can
be set instead.
