### PR TITLE
Add GCC flag "-Wno-narrowing" on 3rd party to correct x86_64 build issue...

### DIFF
--- a/Source/config.gyp
+++ b/Source/config.gyp
@@ -84,6 +84,11 @@
           # nullptr) conflict with upcoming c++0x types.
           'cflags_cc': ['-Wno-c++0x-compat'],
         }],
+        ['gcc_version>=47', {
+          # Disable warnings about narrowing conversion due to C++11 std.
+          # For more details, see: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=50011
+          'cflags_cc': ['-Wno-narrowing'],
+        }],
         ['OS=="linux" and target_arch=="arm"', {
           # Due to a bug in gcc arm, we get warnings about uninitialized
           # timesNewRoman.unstatic.3258 and colorTransparent.unstatic.4879.


### PR DESCRIPTION
Hi,

Please find below a proposal to avoid 64-bit compilation build issues with GCC >= 4.7

Regards,

....

Change-Id: I5b8a3019e7f72fcc1f70e8f7e54761b5969f5f29
Signed-off-by: Yannick GICQUEL yannick.gicquel@open.eurogiciel.org
