### PR TITLE
[Backport r167358] fix may be used uninitialized warning on older compilers

### DIFF
--- a/Source/core/rendering/FastTextAutosizer.h
+++ b/Source/core/rendering/FastTextAutosizer.h
@@ -77,6 +77,8 @@ public:
                 }
                 m_block = block;
                 m_textAutosizer->beginLayout(m_block);
+            } else {
+                m_block = 0;
             }
         }
 


### PR DESCRIPTION
Some older compilers give a warning that m_block may be used
  uninitialized, since it's not always initialised in the LayoutScope
  constructor.

  Review URL: https://codereview.chromium.org/170233006

Author: mostynb@opera.com

This should fix the build problems in Tizen Generic:
https://build.crosswalk-project.org/builders/Crosswalk%20Tizen%20Generic%2064-bits/builds/38/steps/compile/logs/stdio/text
