### PR TITLE
[Backport r167638] Always initialize LayoutScope::m_block.

### DIFF
--- a/Source/core/rendering/FastTextAutosizer.h
+++ b/Source/core/rendering/FastTextAutosizer.h
@@ -68,6 +68,7 @@ public:
     class LayoutScope {
     public:
         explicit LayoutScope(Document& document, RenderBlock* block)
+            : m_block(0)
         {
             m_textAutosizer = document.fastTextAutosizer();
             if (m_textAutosizer) {
@@ -77,8 +78,6 @@ public:
                 }
                 m_block = block;
                 m_textAutosizer->beginLayout(m_block);
-            } else {
-                m_block = 0;
             }
         }
 


### PR DESCRIPTION
While the missing initialization was completely harmless,
  I got a compilation error with gcc 4.7.2.

  BUG=none

  Review URL: https://codereview.chromium.org/176433002

Author: mstensho@opera.com

This is another change needed to fix the build with Tizen Generic. Verified to
be the last one.
