### PR TITLE
Allow enabling 'ScreenOrientation' feature outside Blink.

### DIFF
--- a/Source/web/WebRuntimeFeatures.cpp
+++ b/Source/web/WebRuntimeFeatures.cpp
@@ -281,4 +281,9 @@ void WebRuntimeFeatures::enablePreciseMemoryInfo(bool enable)
     RuntimeEnabledFeatures::setPreciseMemoryInfoEnabled(enable);
 }
 
+void WebRuntimeFeatures::enableScreenOrientation(bool enable)
+{
+    RuntimeEnabledFeatures::setScreenOrientationEnabled(enable);
+}
+
 } // namespace blink

--- a/public/web/WebRuntimeFeatures.h
+++ b/public/web/WebRuntimeFeatures.h
@@ -126,6 +126,8 @@ public:
     BLINK_EXPORT static void enableTargetedStyleRecalc(bool);
 
     BLINK_EXPORT static void enablePreciseMemoryInfo(bool);
+    
+    BLINK_EXPORT static void enableScreenOrientation(bool);
 
 private:
     WebRuntimeFeatures();


### PR DESCRIPTION
Upstream link: https://codereview.chromium.org/336513003/

SSIA. This patch introduces the 'enableScreenOrientation()' setter
to the WebRuntimeFeatures class, so that 'ScreenOrientation' feature
can be enabled outside Blink.
