### PR TITLE
Chromium CPU profiler: source line support

### DIFF
--- a/Source/core/inspector/ScriptProfile.cpp
+++ b/Source/core/inspector/ScriptProfile.cpp
@@ -64,6 +64,26 @@ double ScriptProfile::endTime() const
     return static_cast<double>(m_profile->GetEndTime()) / 1000000;
 }
 
+static RefPtr<TypeBuilder::Array<TypeBuilder::Profiler::LineTick> > buildInspectorObjectForLineTicks(const v8::CpuProfileNode* node)
+{
+    RefPtr<TypeBuilder::Array<TypeBuilder::Profiler::LineTick> > array = TypeBuilder::Array<TypeBuilder::Profiler::LineTick>::create();
+    unsigned int lineCount = node->GetHitLineCount();
+    if (lineCount) {
+        Vector<v8::LineTick> entries(lineCount);
+        bool res = node->GetLineTicks(&entries[0], lineCount);
+        if (res) {
+            for (unsigned int i = 0; i < lineCount; i++) {
+                RefPtr<TypeBuilder::Profiler::LineTick> line = TypeBuilder::Profiler::LineTick::create()
+                    .setLine(entries[i].line)
+                    .setTicks(entries[i].ticks);
+                array->addItem(line);
+                line.release();
+            }
+        }
+    }
+    return array;
+}
+
 static PassRefPtr<TypeBuilder::Profiler::CPUProfileNode> buildInspectorObjectFor(const v8::CpuProfileNode* node)
 {
     v8::HandleScope handleScope(v8::Isolate::GetCurrent());
@@ -75,6 +95,8 @@ static PassRefPtr<TypeBuilder::Profiler::CPUProfileNode> buildInspectorObjectFor
         children->addItem(buildInspectorObjectFor(child));
     }
 
+    RefPtr<TypeBuilder::Array<TypeBuilder::Profiler::LineTick> > lineTicks = buildInspectorObjectForLineTicks(node);
+
     RefPtr<TypeBuilder::Profiler::CPUProfileNode> result = TypeBuilder::Profiler::CPUProfileNode::create()
         .setFunctionName(toCoreString(node->GetFunctionName()))
         .setScriptId(String::number(node->GetScriptId()))
@@ -84,6 +106,7 @@ static PassRefPtr<TypeBuilder::Profiler::CPUProfileNode> buildInspectorObjectFor
         .setHitCount(node->GetHitCount())
         .setCallUID(node->GetCallUid())
         .setChildren(children.release())
+        .setLineTicks(lineTicks.release())
         .setDeoptReason(node->GetBailoutReason())
         .setId(node->GetNodeId());
     return result.release();

--- a/Source/devtools/protocol.json
+++ b/Source/devtools/protocol.json
@@ -3347,7 +3347,8 @@
                     { "name": "callUID", "type": "number", "description": "Call UID." },
                     { "name": "children", "type": "array", "items": { "$ref": "CPUProfileNode" }, "description": "Child nodes." },
                     { "name": "deoptReason", "type": "string", "description": "The reason of being not optimized. The function may be deoptimized or marked as don't optimize."},
-                    { "name": "id", "type": "integer", "description": "Unique id of the node." }
+                    { "name": "id", "type": "integer", "description": "Unique id of the node." },
+                    { "name": "lineTicks", "type": "array", "items": { "$ref": "LineTick" }, "description": "A set of source line ticks." }
                 ]
             },
             {
@@ -3360,6 +3361,15 @@
                     { "name": "endTime", "type": "number", "description": "Profiling end time in seconds." },
                     { "name": "samples", "optional": true, "type": "array", "items": { "type": "integer" }, "description": "Ids of samples top nodes." },
                     { "name": "timestamps", "optional": true, "type": "array", "items": { "type": "number" }, "description": "Timestamps of the samples in microseconds." }
+                ]
+            },
+            {
+                "id": "LineTick",
+                "type": "object",
+                "description": "Specifies a number of samples attributed to a certain source line.",
+                "properties": [
+                    { "name": "line", "type": "integer", "description": "Source line number." },
+                    { "name": "ticks", "type": "integer", "description": "Number of samples attributed to a source line number." }
                 ]
             }
         ],


### PR DESCRIPTION
This is the second and final part of adding source line support in Chromium CPU profiler that needs to be done to move XDK CPU profiler on the same way as CDT uses.

In brief, we need to do two things:
1) Map the samples to source lines during profiling session and add new V8 public API to get the hit source lines. These changes are already merged into v8-crosswalk.
2) The Chrome profilers works as follows: Chrome Browser ==(a "start/stop profiling" command)==> WebKit (WebSocket) ==> WebKit(InspectorBackendDispatcher) =="start/stop profiling"==> WebKit(InspectorProfilerAgent) ==V8 Public APIs (StartProfiling/Stopprofiling)==> V8.
So, on StopProfiling command, WebKit(InspectorProfilerAgent) gets the collected results (using V8 public API) and packs them into JSON to send back to Chrome browser.

This patch implements writing info about the hit source lines in JSON data to be sent back to Chromium browser.
(cherry picked from commit f16d9209f530d0ab2a2572f0679b14ea7d2f96dc)
