### PR TITLE
Document.title getter should return text of title element and setter sho...

### DIFF
--- a/LayoutTests/fast/dom/Document/title-01-expected.txt
+++ b/LayoutTests/fast/dom/Document/title-01-expected.txt
@@ -1,0 +1,7 @@
+This is a testharness.js-based test.
+PASS document.title with head blown away 
+PASS document.title with head blown away 1 
+PASS Untitled 2 
+PASS PASS 3 
+Harness: the test ran to completion.
+

--- a/LayoutTests/fast/dom/Document/title-01.html
+++ b/LayoutTests/fast/dom/Document/title-01.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>document.title with head blown away</title>
+<link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
+<link rel="help" href="http://www.whatwg.org/html5/#document.title">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<link rel="stylesheet" href="../../../resources/testharness.css">
+</head>
+<body>
+<script>
+test(function() {
+    assert_equals(document.title, "document.title with head blown away");
+})
+test(function() {
+    var head = document.getElementsByTagName("head")[0];
+    assert_true(!!head, "Head gone?!")
+    head.parentNode.removeChild(head);
+    assert_false(!!document.getElementsByTagName("head")[0], "Head still there?!")
+    document.title = "FAIL";
+    assert_equals(document.title, "");
+})
+test(function() {
+    var title2 = document.createElement("title");
+    title2.appendChild(document.createTextNode("PASS"));
+    document.body.appendChild(title2);
+    assert_equals(document.title, "PASS");
+})
+test(function() {
+    var title3 = document.createElement("title");
+    title3.appendChild(document.createTextNode("PASS2"));
+    document.documentElement.insertBefore(title3, document.body);
+    assert_equals(document.title, "PASS2");
+})
+</script>
+</body>
+</html>

--- a/LayoutTests/svg/custom/multiple-title-elements-expected.txt
+++ b/LayoutTests/svg/custom/multiple-title-elements-expected.txt
@@ -1,3 +1,4 @@
 Expected , got : PASS
 Expected First title, got First title: PASS
 Expected First title, got First title: PASS
+Expected Second title, got Second title: PASS

--- a/LayoutTests/svg/custom/multiple-title-elements.svg
+++ b/LayoutTests/svg/custom/multiple-title-elements.svg
@@ -43,6 +43,8 @@ function test()
     expect('First title', document.title);
     document.documentElement.appendChild(createTitleElement('Second title'));
     expect('First title', document.title);
+    document.documentElement.removeChild(document.getElementsByTagName('title')[0]);
+    expect('Second title', document.title);
 }
 </script>
 <g id="console">

--- a/Source/core/dom/Document.cpp
+++ b/Source/core/dom/Document.cpp
@@ -173,6 +173,7 @@
 #include "core/rendering/compositing/RenderLayerCompositor.h"
 #include "core/svg/SVGDocumentExtensions.h"
 #include "core/svg/SVGFontFaceElement.h"
+#include "core/svg/SVGTitleElement.h"
 #include "core/svg/SVGUseElement.h"
 #include "core/workers/SharedWorkerRepositoryClient.h"
 #include "core/xml/XSLTProcessor.h"
@@ -448,7 +449,6 @@ Document::Document(const DocumentInit& initializer, DocumentClassFlags documentC
     , m_updateFocusAppearanceRestoresSelection(false)
     , m_containsPlugins(false)
     , m_ignoreDestructiveWriteCount(0)
-    , m_titleSetExplicitly(false)
     , m_markers(adoptPtrWillBeNoop(new DocumentMarkerController))
     , m_updateFocusAppearanceTimer(this, &Document::updateFocusAppearanceTimerFired)
     , m_cssTarget(nullptr)
@@ -1372,14 +1372,14 @@ void Document::updateTitle(const String& title)
 void Document::setTitle(const String& title)
 {
     // Title set by JavaScript -- overrides any title elements.
-    m_titleSetExplicitly = true;
     if (!isHTMLDocument() && !isXHTMLDocument())
         m_titleElement = nullptr;
     else if (!m_titleElement) {
-        if (HTMLElement* headElement = head()) {
-            m_titleElement = HTMLTitleElement::create(*this);
-            headElement->appendChild(m_titleElement.get());
-        }
+        HTMLElement* headElement = head();
+        if (!headElement)
+            return;
+        m_titleElement = HTMLTitleElement::create(*this);
+        headElement->appendChild(m_titleElement.get());
     }
 
     if (isHTMLTitleElement(m_titleElement))
@@ -1388,16 +1388,23 @@ void Document::setTitle(const String& title)
         updateTitle(title);
 }
 
-void Document::setTitleElement(const String& title, Element* titleElement)
+void Document::setTitleElement(Element* titleElement)
 {
-    if (titleElement != m_titleElement) {
-        if (m_titleElement || m_titleSetExplicitly)
-            // Only allow the first title element to change the title -- others have no effect.
-            return;
+    // Only allow the first title element to change the title -- others have no effect.
+    if (m_titleElement && m_titleElement != titleElement) {
+        if (isHTMLDocument() || isXHTMLDocument()) {
+            m_titleElement = Traversal<HTMLTitleElement>::firstWithin(*this);
+        } else if (isSVGDocument()) {
+            m_titleElement = Traversal<SVGTitleElement>::firstWithin(*this);
+        }
+    } else {
         m_titleElement = titleElement;
     }
 
-    updateTitle(title);
+    if (isHTMLTitleElement(m_titleElement))
+        updateTitle(toHTMLTitleElement(m_titleElement)->text());
+    else if (isSVGTitleElement(m_titleElement))
+        updateTitle(toSVGTitleElement(m_titleElement)->textContent());
 }
 
 void Document::removeTitle(Element* titleElement)
@@ -1406,13 +1413,14 @@ void Document::removeTitle(Element* titleElement)
         return;
 
     m_titleElement = nullptr;
-    m_titleSetExplicitly = false;
 
-    // FIXME: This is broken for SVG.
-    // Update title based on first title element in the head, if one exists.
-    if (HTMLElement* headElement = head()) {
-        if (HTMLTitleElement* title = Traversal<HTMLTitleElement>::firstChild(*headElement))
-            setTitleElement(title->text(), title);
+    // Update title based on first title element in the document, if one exists.
+    if (isHTMLDocument() || isXHTMLDocument()) {
+        if (HTMLTitleElement* title = Traversal<HTMLTitleElement>::firstWithin(*this))
+            setTitleElement(title);
+    } else if (isSVGDocument()) {
+        if (SVGTitleElement* title = Traversal<SVGTitleElement>::firstWithin(*this))
+            setTitleElement(title);
     }
 
     if (!m_titleElement)

--- a/Source/core/dom/Document.h
+++ b/Source/core/dom/Document.h
@@ -739,7 +739,7 @@ public:
     void setTitle(const String&);
 
     Element* titleElement() const { return m_titleElement.get(); }
-    void setTitleElement(const String& title, Element* titleElement);
+    void setTitleElement(Element*);
     void removeTitle(Element* titleElement);
 
     const AtomicString& dir();
@@ -1277,7 +1277,6 @@ private:
 
     String m_title;
     String m_rawTitle;
-    bool m_titleSetExplicitly;
     RefPtrWillBeMember<Element> m_titleElement;
 
     OwnPtr<AXObjectCache> m_axObjectCache;

--- a/Source/core/html/HTMLTitleElement.cpp
+++ b/Source/core/html/HTMLTitleElement.cpp
@@ -50,7 +50,7 @@ Node::InsertionNotificationRequest HTMLTitleElement::insertedInto(ContainerNode*
 {
     HTMLElement::insertedInto(insertionPoint);
     if (inDocument() && !isInShadowTree())
-        document().setTitleElement(text(), this);
+        document().setTitleElement(this);
     return InsertionDone;
 }
 
@@ -65,7 +65,7 @@ void HTMLTitleElement::childrenChanged(bool changedByParser, Node* beforeChange,
 {
     HTMLElement::childrenChanged(changedByParser, beforeChange, afterChange, childCountDelta);
     if (inDocument() && !isInShadowTree() && !m_ignoreTitleUpdatesWhenChildrenChange)
-        document().setTitleElement(text(), this);
+        document().setTitleElement(this);
 }
 
 String HTMLTitleElement::text() const

--- a/Source/core/svg/SVGTitleElement.cpp
+++ b/Source/core/svg/SVGTitleElement.cpp
@@ -40,7 +40,7 @@ Node::InsertionNotificationRequest SVGTitleElement::insertedInto(ContainerNode* 
     if (!rootParent->inDocument())
         return InsertionDone;
     if (firstChild() && document().isSVGDocument())
-        document().setTitleElement(textContent(), this);
+        document().setTitleElement(this);
     return InsertionDone;
 }
 
@@ -55,7 +55,7 @@ void SVGTitleElement::childrenChanged(bool changedByParser, Node* beforeChange, 
 {
     SVGElement::childrenChanged(changedByParser, beforeChange, afterChange, childCountDelta);
     if (inDocument() && document().isSVGDocument())
-        document().setTitleElement(textContent(), this);
+        document().setTitleElement(this);
 }
 
 }


### PR DESCRIPTION
...uld stop when head element is null

SPEC: http://www.whatwg.org/specs/web-apps/current-work/#document.title

This CL allowed implicit title set from Document::setTitleElement()
and stopped operation on setter when head element is null as per specification.

In addition, with this change, failed test cases will be passed in
http://w3c-test.org/html/dom/documents/dom-tree-accessors/document.title-01.html

Behavior in other browsers:
*)FF: PASS
*)IE: PASS

Plus, this CL deleted obsolete title argument from Document::setTitleElement.

TEST=LayoutTests/fast/dom/Document/title-01.html
    ,LayoutTests/svg/custom/multiple-title-elements.svg

Review URL: https://codereview.chromium.org/384413003

git-svn-id: svn://svn.chromium.org/blink/trunk@178889 bbb929c8-8fbe-4397-9dbb-9b2b20218538
(cherry picked from commit 221337fbfa326e848614b6400dbfd00c59eb0431)
