### PR TITLE
Fix the --enable-viewport command line option

### DIFF
--- a/Source/web/WebSettingsImpl.cpp
+++ b/Source/web/WebSettingsImpl.cpp
@@ -33,6 +33,7 @@
 
 #include "core/frame/Settings.h"
 #include "core/inspector/InspectorController.h"
+#include "platform/RuntimeEnabledFeatures.h"
 #include "platform/graphics/DeferredImageDecoder.h"
 
 #include "public/platform/WebString.h"
@@ -615,6 +616,7 @@ void WebSettingsImpl::setMediaPlaybackRequiresUserGesture(bool required)
 
 void WebSettingsImpl::setViewportEnabled(bool enabled)
 {
+    RuntimeEnabledFeatures::setCSSViewportEnabled(enabled);
     m_settings->setViewportEnabled(enabled);
 }
 


### PR DESCRIPTION
This is the fix for
https://code.google.com/p/chromium/issues/detail?id=420535

and should be removed once it is fixed upstream.

BUG=XWALK-2043
