### PR TITLE
[Backport Patch] Use glDiscardFramebuffer instead of glClear

### DIFF
--- a/Source/core/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/core/html/canvas/WebGLRenderingContextBase.cpp
@@ -814,7 +814,7 @@ bool WebGLRenderingContextBase::clearIfComposited(GLbitfield mask)
     if (isContextLost())
         return false;
 
-    if (!drawingBuffer()->layerComposited() || m_layerCleared
+    if (!drawingBuffer()->layerComposited() || drawingBuffer()->discardFramebufferSupported() || m_layerCleared
         || m_requestedAttributes->preserveDrawingBuffer() || (mask && m_framebufferBinding))
         return false;
 

--- a/Source/platform/graphics/gpu/DrawingBuffer.cpp
+++ b/Source/platform/graphics/gpu/DrawingBuffer.cpp
@@ -106,7 +106,11 @@ PassRefPtr<DrawingBuffer> DrawingBuffer::create(PassOwnPtr<WebGraphicsContext3D>
     if (packedDepthStencilSupported)
         extensionsUtil->ensureExtensionEnabled("GL_OES_packed_depth_stencil");
 
-    RefPtr<DrawingBuffer> drawingBuffer = adoptRef(new DrawingBuffer(context, extensionsUtil.release(), multisampleSupported, packedDepthStencilSupported, preserve, requestedAttributes, contextEvictionManager));
+    bool discardFramebufferSupported = extensionsUtil->supportsExtension("GL_EXT_discard_framebuffer");
+    if (discardFramebufferSupported)
+        extensionsUtil->ensureExtensionEnabled("GL_EXT_discard_framebuffer");
+    RefPtr<DrawingBuffer> drawingBuffer = adoptRef(new DrawingBuffer(context, extensionsUtil.release(), multisampleSupported, packedDepthStencilSupported, discardFramebufferSupported, preserve, requestedAttributes, contextEvictionManager));
+
     if (!drawingBuffer->initialize(size)) {
         drawingBuffer->beginDestruction();
         return PassRefPtr<DrawingBuffer>();
@@ -118,6 +122,7 @@ DrawingBuffer::DrawingBuffer(PassOwnPtr<WebGraphicsContext3D> context,
     PassOwnPtr<Extensions3DUtil> extensionsUtil,
     bool multisampleExtensionSupported,
     bool packedDepthStencilExtensionSupported,
+    bool discardFramebufferSupported,
     PreserveDrawingBuffer preserve,
     WebGraphicsContext3D::Attributes requestedAttributes,
     PassRefPtr<ContextEvictionManager> contextEvictionManager)
@@ -132,6 +137,7 @@ DrawingBuffer::DrawingBuffer(PassOwnPtr<WebGraphicsContext3D> context,
     , m_requestedAttributes(requestedAttributes)
     , m_multisampleExtensionSupported(multisampleExtensionSupported)
     , m_packedDepthStencilExtensionSupported(packedDepthStencilExtensionSupported)
+    , m_discardFramebufferSupported(discardFramebufferSupported)
     , m_fbo(0)
     , m_depthStencilBuffer(0)
     , m_depthBuffer(0)
@@ -267,6 +273,12 @@ bool DrawingBuffer::prepareMailbox(WebExternalTextureMailbox* outMailbox, WebExt
             m_context->framebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_colorBuffer.textureId, 0, m_sampleCount);
         else
             m_context->framebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_colorBuffer.textureId, 0);
+
+        if (m_discardFramebufferSupported) {
+            // Explicitly discard framebuffer to save GPU memory bandwidth for tile-based GPU arch.
+            const WGC3Denum attachments[3] = { GL_COLOR_ATTACHMENT0, GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT};
+            m_context->discardFramebufferEXT(GL_FRAMEBUFFER, 3, attachments);
+        }
     } else {
         m_context->copyTextureCHROMIUM(GL_TEXTURE_2D, m_colorBuffer.textureId, frontColorBufferMailbox->textureInfo.textureId, 0, GL_RGBA, GL_UNSIGNED_BYTE);
     }

--- a/Source/platform/graphics/gpu/DrawingBuffer.h
+++ b/Source/platform/graphics/gpu/DrawingBuffer.h
@@ -136,6 +136,8 @@ public:
 
     Platform3DObject framebuffer() const;
 
+    bool discardFramebufferSupported() const { return m_discardFramebufferSupported; }
+
     void markContentsChanged();
     void markLayerComposited();
     bool layerComposited() const;
@@ -169,6 +171,7 @@ protected: // For unittests
         PassOwnPtr<Extensions3DUtil>,
         bool multisampleExtensionSupported,
         bool packedDepthStencilExtensionSupported,
+        bool discardFramebufferSupported,
         PreserveDrawingBuffer,
         WebGraphicsContext3D::Attributes requestedAttributes,
         PassRefPtr<ContextEvictionManager>);
@@ -239,6 +242,7 @@ private:
     WebGraphicsContext3D::Attributes m_requestedAttributes;
     bool m_multisampleExtensionSupported;
     bool m_packedDepthStencilExtensionSupported;
+    bool m_discardFramebufferSupported;
     Platform3DObject m_fbo;
     // DrawingBuffer's output is double-buffered. m_colorBuffer is the back buffer.
     TextureInfo m_colorBuffer;

--- a/Source/platform/graphics/gpu/DrawingBufferTest.cpp
+++ b/Source/platform/graphics/gpu/DrawingBufferTest.cpp
@@ -190,7 +190,7 @@ public:
         PreserveDrawingBuffer preserve,
         PassRefPtr<ContextEvictionManager> contextEvictionManager)
         : DrawingBuffer(context, extensionsUtil, false /* multisampleExtensionSupported */,
-            false /* packedDepthStencilExtensionSupported */, preserve, WebGraphicsContext3D::Attributes(), contextEvictionManager)
+            false /* packedDepthStencilExtensionSupported */, false /* discardFramebufferSupported */, preserve, WebGraphicsContext3D::Attributes(), contextEvictionManager)
         , m_live(0)
     { }
 


### PR DESCRIPTION
This patch would have over 30% fps performance improvement for
Discard-mode WebGL.

Review URL: https://codereview.chromium.org/614883002

BUG=XWALK-2719
