### PR TITLE
Revert "[Backport Patch] Use glDiscardFramebuffer instead of glClear"

### DIFF
--- a/Source/core/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/core/html/canvas/WebGLRenderingContextBase.cpp
@@ -814,7 +814,7 @@ bool WebGLRenderingContextBase::clearIfComposited(GLbitfield mask)
     if (isContextLost())
         return false;
 
-    if (!drawingBuffer()->layerComposited() || drawingBuffer()->discardFramebufferSupported() || m_layerCleared
+    if (!drawingBuffer()->layerComposited() || m_layerCleared
         || m_requestedAttributes->preserveDrawingBuffer() || (mask && m_framebufferBinding))
         return false;
 

--- a/Source/platform/graphics/gpu/DrawingBuffer.cpp
+++ b/Source/platform/graphics/gpu/DrawingBuffer.cpp
@@ -106,11 +106,7 @@ PassRefPtr<DrawingBuffer> DrawingBuffer::create(PassOwnPtr<WebGraphicsContext3D>
     if (packedDepthStencilSupported)
         extensionsUtil->ensureExtensionEnabled("GL_OES_packed_depth_stencil");
 
-    bool discardFramebufferSupported = extensionsUtil->supportsExtension("GL_EXT_discard_framebuffer");
-    if (discardFramebufferSupported)
-        extensionsUtil->ensureExtensionEnabled("GL_EXT_discard_framebuffer");
-    RefPtr<DrawingBuffer> drawingBuffer = adoptRef(new DrawingBuffer(context, extensionsUtil.release(), multisampleSupported, packedDepthStencilSupported, discardFramebufferSupported, preserve, requestedAttributes, contextEvictionManager));
-
+    RefPtr<DrawingBuffer> drawingBuffer = adoptRef(new DrawingBuffer(context, extensionsUtil.release(), multisampleSupported, packedDepthStencilSupported, preserve, requestedAttributes, contextEvictionManager));
     if (!drawingBuffer->initialize(size)) {
         drawingBuffer->beginDestruction();
         return PassRefPtr<DrawingBuffer>();
@@ -122,7 +118,6 @@ DrawingBuffer::DrawingBuffer(PassOwnPtr<WebGraphicsContext3D> context,
     PassOwnPtr<Extensions3DUtil> extensionsUtil,
     bool multisampleExtensionSupported,
     bool packedDepthStencilExtensionSupported,
-    bool discardFramebufferSupported,
     PreserveDrawingBuffer preserve,
     WebGraphicsContext3D::Attributes requestedAttributes,
     PassRefPtr<ContextEvictionManager> contextEvictionManager)
@@ -137,7 +132,6 @@ DrawingBuffer::DrawingBuffer(PassOwnPtr<WebGraphicsContext3D> context,
     , m_requestedAttributes(requestedAttributes)
     , m_multisampleExtensionSupported(multisampleExtensionSupported)
     , m_packedDepthStencilExtensionSupported(packedDepthStencilExtensionSupported)
-    , m_discardFramebufferSupported(discardFramebufferSupported)
     , m_fbo(0)
     , m_depthStencilBuffer(0)
     , m_depthBuffer(0)
@@ -273,12 +267,6 @@ bool DrawingBuffer::prepareMailbox(WebExternalTextureMailbox* outMailbox, WebExt
             m_context->framebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_colorBuffer.textureId, 0, m_sampleCount);
         else
             m_context->framebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_colorBuffer.textureId, 0);
-
-        if (m_discardFramebufferSupported) {
-            // Explicitly discard framebuffer to save GPU memory bandwidth for tile-based GPU arch.
-            const WGC3Denum attachments[3] = { GL_COLOR_ATTACHMENT0, GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT};
-            m_context->discardFramebufferEXT(GL_FRAMEBUFFER, 3, attachments);
-        }
     } else {
         m_context->copyTextureCHROMIUM(GL_TEXTURE_2D, m_colorBuffer.textureId, frontColorBufferMailbox->textureInfo.textureId, 0, GL_RGBA, GL_UNSIGNED_BYTE);
     }

--- a/Source/platform/graphics/gpu/DrawingBuffer.h
+++ b/Source/platform/graphics/gpu/DrawingBuffer.h
@@ -136,8 +136,6 @@ public:
 
     Platform3DObject framebuffer() const;
 
-    bool discardFramebufferSupported() const { return m_discardFramebufferSupported; }
-
     void markContentsChanged();
     void markLayerComposited();
     bool layerComposited() const;
@@ -171,7 +169,6 @@ protected: // For unittests
         PassOwnPtr<Extensions3DUtil>,
         bool multisampleExtensionSupported,
         bool packedDepthStencilExtensionSupported,
-        bool discardFramebufferSupported,
         PreserveDrawingBuffer,
         WebGraphicsContext3D::Attributes requestedAttributes,
         PassRefPtr<ContextEvictionManager>);
@@ -242,7 +239,6 @@ private:
     WebGraphicsContext3D::Attributes m_requestedAttributes;
     bool m_multisampleExtensionSupported;
     bool m_packedDepthStencilExtensionSupported;
-    bool m_discardFramebufferSupported;
     Platform3DObject m_fbo;
     // DrawingBuffer's output is double-buffered. m_colorBuffer is the back buffer.
     TextureInfo m_colorBuffer;

--- a/Source/platform/graphics/gpu/DrawingBufferTest.cpp
+++ b/Source/platform/graphics/gpu/DrawingBufferTest.cpp
@@ -190,7 +190,7 @@ public:
         PreserveDrawingBuffer preserve,
         PassRefPtr<ContextEvictionManager> contextEvictionManager)
         : DrawingBuffer(context, extensionsUtil, false /* multisampleExtensionSupported */,
-            false /* packedDepthStencilExtensionSupported */, false /* discardFramebufferSupported */, preserve, WebGraphicsContext3D::Attributes(), contextEvictionManager)
+            false /* packedDepthStencilExtensionSupported */, preserve, WebGraphicsContext3D::Attributes(), contextEvictionManager)
         , m_live(0)
     { }
 


### PR DESCRIPTION
There was a follow-up to this patch upstream in crrev.com/656053002
which reverted the performance gains originally obtained.

XWALK-2719 and the original pull request #25 contains more information
about what happened, and crrev.com/667733002 is fixing it in a different
way.

For now, let's wait for everything to settle upstream and go back to the
original M39 behavior.

This reverts commit 90a30f1f6273a6b6bf25263c18ba453c99b6f570.

Relate to: XWALK-2719
