### PR TITLE
The Chrome DevTools protocol part of the XDK

### DIFF
--- a/Source/bindings/core/v8/ScriptProfiler.cpp
+++ b/Source/bindings/core/v8/ScriptProfiler.cpp
@@ -307,4 +307,58 @@ void ScriptProfiler::setIdle(bool isIdle)
         profiler->SetIdle(isIdle);
 }
 
+namespace {
+
+class HeapXDKStream : public v8::OutputStream {
+public:
+    HeapXDKStream(ScriptProfiler::OutputStream* stream) : m_stream(stream) { }
+    virtual void EndOfStream() OVERRIDE { }
+
+    virtual WriteResult WriteAsciiChunk(char* data, int size) OVERRIDE
+    {
+        ASSERT(false);
+        return kAbort;
+    }
+
+    virtual WriteResult WriteHeapXDKChunk(const char* symbols, int symbolsSize,
+                                          const char* frames, int framesSize,
+                                          const char* types, int typesSize,
+                                          const char* chunks, int chunksSize,
+                                          const char* retentions, 
+                                          int retentionSize) OVERRIDE
+    {
+        m_stream->write(symbols, symbolsSize, frames, framesSize,
+                        types, typesSize, chunks, chunksSize,
+                        retentions, retentionSize);
+        return kContinue;
+    }
+
+private:
+    ScriptProfiler::OutputStream* m_stream;
+};
+
+}
+
+void ScriptProfiler::requestHeapXDKUpdate(ScriptProfiler::OutputStream* stream)
+{
+    HeapXDKStream heapXDKStream(stream);
+    v8::Isolate::GetCurrent()->GetHeapProfiler()->GetHeapXDKStats(
+            &heapXDKStream);
+}
+
+void ScriptProfiler::startTrackingHeapObjectsXDK(int stackDepth,
+                                                 bool retentions)
+{
+    v8::Isolate::GetCurrent()->GetHeapProfiler()->StartTrackingHeapObjectsXDK(
+            stackDepth, retentions);
+}
+
+PassRefPtr<HeapProfileXDK> ScriptProfiler::stopTrackingHeapObjectsXDK()
+{
+    return HeapProfileXDK::create(
+            v8::Isolate::GetCurrent()
+                    ->GetHeapProfiler()->StopTrackingHeapObjectsXDK());
+}
+
+
 } // namespace blink

--- a/Source/bindings/core/v8/ScriptProfiler.h
+++ b/Source/bindings/core/v8/ScriptProfiler.h
@@ -62,6 +62,11 @@ public:
     public:
         virtual ~OutputStream() { }
         virtual void write(const uint32_t* chunk, const int size) = 0;
+        virtual void write(const char* symbols, int symbolsSize,
+                           const char* frames, int framesSize,
+                           const char* types, int typesSize,
+                           const char* chunks, int chunksSize,
+                           const char* retentions, int retentionsSize) { };
     };
 
     static void collectGarbage();
@@ -75,6 +80,9 @@ public:
     static void startTrackingHeapObjects(bool trackAllocations);
     static void stopTrackingHeapObjects();
     static unsigned requestHeapStatsUpdate(OutputStream*);
+    static void startTrackingHeapObjectsXDK(int stackDepth, bool retentions);
+    static PassRefPtr<HeapProfileXDK> stopTrackingHeapObjectsXDK();
+    static void requestHeapXDKUpdate(OutputStream*);
     static void initialize();
     static void visitNodeWrappers(WrappedNodeVisitor*);
     static HashMap<String, double>* currentProfileNameIdleTimeMap();

--- a/Source/core/inspector/InspectorHeapProfilerAgent.cpp
+++ b/Source/core/inspector/InspectorHeapProfilerAgent.cpp
@@ -61,6 +61,20 @@ private:
     Timer<HeapStatsUpdateTask> m_timer;
 };
 
+
+class InspectorHeapProfilerAgent::HeapXDKUpdateTask FINAL : public NoBaseWillBeGarbageCollectedFinalized<InspectorHeapProfilerAgent::HeapXDKUpdateTask> {
+public:
+    HeapXDKUpdateTask(InspectorHeapProfilerAgent*);
+    void startTimer(float sav);
+    void resetTimer() { m_timer.stop(); }
+    void onTimer(Timer<HeapXDKUpdateTask>*);
+
+private:
+    InspectorHeapProfilerAgent* m_heapProfilerAgent;
+    Timer<HeapXDKUpdateTask> m_timer;
+};
+
+
 PassOwnPtrWillBeRawPtr<InspectorHeapProfilerAgent> InspectorHeapProfilerAgent::create(InjectedScriptManager* injectedScriptManager)
 {
     return adoptPtrWillBeNoop(new InspectorHeapProfilerAgent(injectedScriptManager));
@@ -323,6 +337,119 @@ void InspectorHeapProfilerAgent::trace(Visitor* visitor)
     visitor->trace(m_injectedScriptManager);
     visitor->trace(m_heapStatsUpdateTask);
     InspectorBaseAgent::trace(visitor);
+}
+
+static PassRefPtr<TypeBuilder::HeapProfiler::HeapEventXDK> createHeapProfileXDK(const HeapProfileXDK& heapProfileXDK)
+{
+    RefPtr<TypeBuilder::HeapProfiler::HeapEventXDK> profile = TypeBuilder::HeapProfiler::HeapEventXDK::create()
+        .setDuration(heapProfileXDK.getDuration())
+        .setSymbols(heapProfileXDK.getSymbols())
+        .setFrames(heapProfileXDK.getFrames())
+        .setTypes(heapProfileXDK.getTypes())
+        .setChunks(heapProfileXDK.getChunks())
+        .setRetentions(heapProfileXDK.getRetentions());
+    return profile.release();
+}
+
+InspectorHeapProfilerAgent::HeapXDKUpdateTask::HeapXDKUpdateTask(InspectorHeapProfilerAgent* heapProfilerAgent)
+    : m_heapProfilerAgent(heapProfilerAgent)
+    , m_timer(this, &HeapXDKUpdateTask::onTimer)
+{
+}
+
+void InspectorHeapProfilerAgent::HeapXDKUpdateTask::onTimer(Timer<HeapXDKUpdateTask>*)
+{
+    // The timer is stopped on m_heapProfilerAgent destruction,
+    // so this method will never be called after m_heapProfilerAgent has been destroyed.
+    m_heapProfilerAgent->requestHeapXDKUpdate();
+}
+
+void InspectorHeapProfilerAgent::HeapXDKUpdateTask::startTimer(float sav)
+{
+    ASSERT(!m_timer.isActive());
+    m_timer.startRepeating(sav, FROM_HERE);
+}
+
+void InspectorHeapProfilerAgent::startTrackingHeapXDK(ErrorString*, 
+                                                      const int* stack_depth,
+                                                      const int* sav,
+                                                      const bool* retentions)
+{
+    m_state->setBoolean(HeapProfilerAgentState::heapObjectsTrackingEnabled, true);
+
+    // inline of startTrackingHeapObjectsInternal(allocationTrackingEnabled);
+    if (m_heapXDKUpdateTask)
+        return;
+    int stackDepth = 8;
+    if (stack_depth) {
+      stackDepth = *stack_depth;
+    }
+    float sav_timer = 1;
+    if (sav) {
+      sav_timer = (float)*sav / 1000.;
+    }
+    bool needRetentions = retentions && *retentions;
+    ScriptProfiler::startTrackingHeapObjectsXDK(stackDepth, needRetentions );
+    m_heapXDKUpdateTask = adoptPtr(new HeapXDKUpdateTask(this));
+    m_heapXDKUpdateTask->startTimer(sav_timer);
+}
+
+class InspectorHeapProfilerAgent::HeapXDKStream FINAL : public ScriptProfiler::OutputStream {
+public:
+    HeapXDKStream(InspectorHeapProfilerAgent* heapProfilerAgent)
+        : m_heapProfilerAgent(heapProfilerAgent)
+    {
+    }
+
+    virtual void write(const uint32_t* chunk, const int size){}
+    virtual void write(const char* symbols, int symbolsSize,
+                       const char* frames, int framesSize,
+                       const char* types, int typesSize,
+                       const char* chunks, int chunksSize,
+                       const char* retentions, int retentionsSize) OVERRIDE
+    {
+        m_heapProfilerAgent->pushHeapXDKUpdate(symbols, symbolsSize, frames, framesSize, 
+                                               types, typesSize, chunks, chunksSize,
+                                               retentions, retentionsSize);
+    }
+private:
+    InspectorHeapProfilerAgent* m_heapProfilerAgent;
+};
+
+void InspectorHeapProfilerAgent::requestHeapXDKUpdate()
+{
+    if (!m_frontend)
+        return;
+    HeapXDKStream stream(this);
+    ScriptProfiler::requestHeapXDKUpdate(&stream);
+}
+
+void InspectorHeapProfilerAgent::stopTrackingHeapXDK(ErrorString* error, RefPtr<TypeBuilder::HeapProfiler::HeapEventXDK>& profile)
+{
+    if (!m_heapXDKUpdateTask) {
+        *error = "Heap object tracking is not started.";
+        return;
+    }
+
+    RefPtr<HeapProfileXDK> heapProfileXDK = ScriptProfiler::stopTrackingHeapObjectsXDK();
+    profile = createHeapProfileXDK(*heapProfileXDK);
+    
+    m_heapXDKUpdateTask->resetTimer();
+    m_heapXDKUpdateTask.clear();
+    m_state->setBoolean(HeapProfilerAgentState::heapObjectsTrackingEnabled, false);
+
+}
+void InspectorHeapProfilerAgent::pushHeapXDKUpdate( const char* symbols, int symbolsSize,
+                                        const char* frames, int framesSize,
+                                        const char* types, int typesSize,
+                                        const char* chunks, int chunksSize,
+                                        const char* retentions, int retentionsSize)
+{
+    if (!m_frontend)
+        return;
+    m_frontend->heapXDKUpdate(String(symbols, symbolsSize), String(frames, framesSize), 
+                              String(types, typesSize), String(chunks, chunksSize), 
+                              String(retentions, retentionsSize));
 }
 
 } // namespace blink

--- a/Source/core/inspector/InspectorHeapProfilerAgent.h
+++ b/Source/core/inspector/InspectorHeapProfilerAgent.h
@@ -6,7 +6,8 @@
  * met:
  *
  *     * Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
+ * notice, this list of co
+ * nditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above
  * copyright notice, this list of conditions and the following disclaimer
  * in the documentation and/or other materials provided with the
@@ -62,6 +63,8 @@ public:
     virtual void disable(ErrorString*) OVERRIDE;
     virtual void startTrackingHeapObjects(ErrorString*, const bool* trackAllocations) OVERRIDE;
     virtual void stopTrackingHeapObjects(ErrorString*, const bool* reportProgress) OVERRIDE;
+    virtual void startTrackingHeapXDK(ErrorString*, const int* stack_depth, const int* sav, const bool* retentions) OVERRIDE;
+    virtual void stopTrackingHeapXDK(ErrorString*, RefPtr<TypeBuilder::HeapProfiler::HeapEventXDK>&) OVERRIDE;
 
     virtual void setFrontend(InspectorFrontend*) OVERRIDE;
     virtual void clearFrontend() OVERRIDE;
@@ -76,10 +79,20 @@ private:
     class HeapStatsStream;
     class HeapStatsUpdateTask;
 
+    class HeapXDKStream;
+    class HeapXDKUpdateTask;
+
     explicit InspectorHeapProfilerAgent(InjectedScriptManager*);
 
     void requestHeapStatsUpdate();
     void pushHeapStatsUpdate(const uint32_t* const data, const int size);
+
+    void requestHeapXDKUpdate();
+    void pushHeapXDKUpdate(const char* symbols, int symbolsSize,
+                           const char* frames, int framesSize,
+                           const char* types, int typesSize,
+                           const char* chunks, int chunksSize,
+                           const char* retentions, int retentionsSize);
 
     void startTrackingHeapObjectsInternal(bool trackAllocations);
     void stopTrackingHeapObjectsInternal();
@@ -88,6 +101,7 @@ private:
     InspectorFrontend::HeapProfiler* m_frontend;
     unsigned m_nextUserInitiatedHeapSnapshotNumber;
     OwnPtrWillBeMember<HeapStatsUpdateTask> m_heapStatsUpdateTask;
+    OwnPtrWillBeMember<HeapXDKUpdateTask> m_heapXDKUpdateTask;
 };
 
 } // namespace blink

--- a/Source/core/inspector/ScriptProfile.cpp
+++ b/Source/core/inspector/ScriptProfile.cpp
@@ -135,4 +135,34 @@ PassRefPtr<TypeBuilder::Array<double> > ScriptProfile::buildInspectorObjectForTi
     return array.release();
 }
 
+String HeapProfileXDK::getSymbols() const
+{
+    return String(m_event->getSymbols()); 
+}
+
+String HeapProfileXDK::getFrames() const
+{
+    return String(m_event->getFrames()); 
+}
+
+String HeapProfileXDK::getTypes() const
+{
+    return String(m_event->getTypes()); 
+}
+
+String HeapProfileXDK::getChunks() const
+{
+    return String(m_event->getChunks()); 
+}
+
+int HeapProfileXDK::getDuration() const
+{
+    return (int)m_event->getDuration(); 
+}
+
+String HeapProfileXDK::getRetentions() const
+{
+    return String(m_event->getRetentions());
+}
+
 } // namespace blink

--- a/Source/core/inspector/ScriptProfile.h
+++ b/Source/core/inspector/ScriptProfile.h
@@ -69,6 +69,30 @@ private:
     double m_idleTime;
 };
 
+class HeapProfileXDK FINAL : public RefCountedWillBeGarbageCollectedFinalized<HeapProfileXDK> {
+public:
+    static PassRefPtrWillBeRawPtr<HeapProfileXDK> create(v8::HeapEventXDK* event)
+    {
+        return adoptRefWillBeNoop(new HeapProfileXDK(event));
+    }
+
+    String getSymbols() const;
+    String getFrames() const;
+    String getTypes() const;
+    String getChunks() const;
+    String getRetentions() const;
+    int getDuration() const;
+
+private:
+    HeapProfileXDK(v8::HeapEventXDK* event)
+        : m_event(event)
+    {
+    }
+
+    v8::HeapEventXDK* m_event;
+
+};
+
 } // namespace blink
 
 #endif // ScriptProfile_h

--- a/Source/devtools/protocol.json
+++ b/Source/devtools/protocol.json
@@ -3705,6 +3705,19 @@
                 "id": "HeapSnapshotObjectId",
                 "type": "string",
                 "description": "Heap snapshot object id."
+            },
+            {
+                "id": "HeapEventXDK",
+                "type": "object",
+                "description": "",
+                "properties": [
+                    { "name": "duration", "type": "integer" },
+                    { "name": "symbols", "type": "string" },
+                    { "name": "frames", "type": "string" },
+                    { "name": "types", "type": "string" },
+                    { "name": "chunks", "type": "string" },
+		    { "name": "retentions", "type": "string" }
+                ]
             }
         ],
         "commands": [
@@ -3726,6 +3739,20 @@
                     { "name": "reportProgress", "type": "boolean", "optional": true, "description": "If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken when the tracking is stopped." }
                 ]
 
+            },
+            {
+                "name": "startTrackingHeapXDK",
+                "parameters": [
+                    { "name": "stack_depth", "type": "integer", "optional": true },
+                    { "name": "sav", "type": "integer", "optional": true },
+                    { "name": "retentions", "type": "boolean", "optional": true }
+                ]
+            },
+            {
+                "name": "stopTrackingHeapXDK",
+                "returns": [
+                    { "name": "profileXDK", "$ref": "HeapEventXDK", "description": "Recorded profile." }
+                ]
             },
             {
                 "name": "takeHeapSnapshot",
@@ -3788,7 +3815,17 @@
                 "parameters": [
                     { "name": "statsUpdate", "type": "array", "items": { "type": "integer" }, "description": "An array of triplets. Each triplet describes a fragment. The first integer is the fragment index, the second integer is a total count of objects for the fragment, the third integer is a total size of the objects for the fragment."}
                 ]
-            }
+            },
+	    {
+                "name": "heapXDKUpdate",
+                "parameters": [
+		    { "name": "symbols", "type": "string" },
+		    { "name": "frames", "type": "string" },
+		    { "name": "types", "type": "string" },
+		    { "name": "chunks", "type": "string" },
+		    { "name": "retentions", "type": "string" }
+		 ]
+	    }
         ]
     },
     {


### PR DESCRIPTION
in-depth allocation tracker

Three new commands are added by analogy with Chrome DevTools
allocation tracker. Start/Stop and Event which is sent by timer.
Command stopTrackingHeapXDK accepts three parameters: stack depth for unwinding,
Sample After Value - period of timer and a flag to collect retention
information or not. Event sends to the host currently collected data about
symbols/callstack/objects. Command stopTrackingHeapXDK returns the final
info witch is similar to Event passed format with one more parameter: duration
of the collection.

Basing on this info consumer can build allocation call tree for any period of
time, annotate source by self and total allocation mertics and annotate
allocation call tree by the objects, which retain other objects in the memory
