### PR TITLE
Fix that enable inspector back will caush compile error

### DIFF
--- a/Source/core/core.gypi
+++ b/Source/core/core.gypi
@@ -5,6 +5,12 @@
     'variables': {
         # Files for which bindings (.cpp and .h files) will be generated
         'core_idl_files': [
+            # Bring the following four lines back when tring to enable inspector.
+            # 'inspector/InjectedScriptHost.idl',
+            # 'inspector/InspectorFrontendHost.idl',
+            # 'inspector/InspectorOverlayHost.idl',
+            # 'inspector/JavaScriptCallFrame.idl',
+
             'animation/Animation.idl',
             'animation/AnimationEffect.idl',
             'animation/AnimationPlayer.idl',

--- a/Source/web/WebDevToolsAgentImpl.h
+++ b/Source/web/WebDevToolsAgentImpl.h
@@ -136,10 +136,10 @@ private:
     InspectorController* inspectorController();
     LocalFrame* mainFrame();
 
-    WebDevToolsAgentClient* m_client;
 #if ENABLE(INSPECTOR)
     int m_debuggerId;
     int m_layerTreeId;
+    WebDevToolsAgentClient* m_client;
     WebViewImpl* m_webViewImpl;
     bool m_attached;
     bool m_generatingEvent;
@@ -161,6 +161,8 @@ private:
 
     typedef Vector<RefPtr<JSONObject> > FrontendMessageQueue;
     FrontendMessageQueue m_frontendMessageQueue;
+#else
+    WebDevToolsAgentClient* m_client;
 #endif // ENABLE(INSPECTOR)
 };
 


### PR DESCRIPTION
The fix can solve the problem of idl file list in gyp.
Just add a reminder in code that some of the lines needs
to be uncommented when want to do that.
