### PR TITLE
[Android] Fix Crosswalk failed to build debug version.

### DIFF
--- a/Source/core/loader/ProgressTracker.cpp
+++ b/Source/core/loader/ProgressTracker.cpp
@@ -95,7 +95,7 @@ void ProgressTracker::dispose()
 {
     if (m_inProgress)
         progressCompleted();
-    ASSERT(!m_frame->isLoading());
+    ASSERT(!m_inProgress);
 }
 
 double ProgressTracker::estimatedProgress() const


### PR DESCRIPTION
Because isLoading api doesn't exist in |m_frame|.