### PR TITLE
Fix XDK code so that it uses size_t instead of int.

### DIFF
--- a/Source/bindings/core/v8/ScriptProfiler.cpp
+++ b/Source/bindings/core/v8/ScriptProfiler.cpp
@@ -329,12 +329,12 @@ public:
         return kAbort;
     }
 
-    virtual WriteResult WriteHeapXDKChunk(const char* symbols, int symbolsSize,
-                                          const char* frames, int framesSize,
-                                          const char* types, int typesSize,
-                                          const char* chunks, int chunksSize,
+    virtual WriteResult WriteHeapXDKChunk(const char* symbols, size_t symbolsSize,
+                                          const char* frames, size_t framesSize,
+                                          const char* types, size_t typesSize,
+                                          const char* chunks, size_t chunksSize,
                                           const char* retentions,
-                                          int retentionSize) override
+                                          size_t retentionSize) override
     {
         m_stream->write(symbols, symbolsSize, frames, framesSize,
                         types, typesSize, chunks, chunksSize,


### PR DESCRIPTION
This is useful to support 64 bits because call sites of that
API usually uses std functions which returns a size_t and size_t
is not going to git into an int on 64 bits. Today it triggers a
warning of potential data loss.