### PR TITLE
[Android] Enable WebCL on devices which only have OpenCL 1.1 support.

### DIFF
--- a/Source/modules/webcl/WebCL.cpp
+++ b/Source/modules/webcl/WebCL.cpp
@@ -60,9 +60,6 @@ PassRefPtr<WebCL> WebCL::create()
 WebCL::~WebCL()
 {
     releaseAll();
-
-    for (auto platform : m_platforms)
-        platform->releaseAll();
 }
 
 Vector<RefPtr<WebCLPlatform>> WebCL::getPlatforms(ExceptionState& es)

--- a/Source/modules/webcl/WebCLCommandQueue.cpp
+++ b/Source/modules/webcl/WebCLCommandQueue.cpp
@@ -106,7 +106,7 @@ void WebCLCommandQueue::finish(WebCLCallback* whenFinished, ExceptionState& es)
 void WebCLCommandQueue::finishCommandQueues(SyncMethod method)
 {
     if (method == ASYNC) {
-        cl_int err = clEnqueueMarkerWithWaitList(m_clCommandQueue, 0, nullptr, &m_eventForCallback);
+        cl_int err = clEnqueueMarker(m_clCommandQueue, &m_eventForCallback);
         if (err != CL_SUCCESS || !m_eventForCallback)
             return;
         WebCLCommandQueueHolder* holder = new WebCLCommandQueueHolder;
@@ -154,7 +154,7 @@ void WebCLCommandQueue::enqueueBarrier(ExceptionState& es)
         return;
     }
 
-    cl_int err = clEnqueueBarrierWithWaitList(m_clCommandQueue, 0, nullptr, nullptr);
+    cl_int err = clEnqueueBarrier(m_clCommandQueue);
     if (err != CL_SUCCESS)
         WebCLException::throwException(err, es);
 }
@@ -175,7 +175,7 @@ void WebCLCommandQueue::enqueueMarker(WebCLEvent* event, ExceptionState& es)
     if (event && !clEventId)
         return;
 
-    cl_int err = clEnqueueMarkerWithWaitList(m_clCommandQueue, 0, nullptr, clEventId);
+    cl_int err = clEnqueueMarker(m_clCommandQueue, clEventId);
     if (err != CL_SUCCESS)
         WebCLException::throwException(err, es);
 }
@@ -196,7 +196,7 @@ void WebCLCommandQueue::enqueueWaitForEvents(const Vector<RefPtr<WebCLEvent>>& e
     if (clEvents.size() != events.size())
         return;
 
-    cl_int err = clEnqueueBarrierWithWaitList(m_clCommandQueue, clEvents.size(), clEvents.data(), nullptr);
+    cl_int err = clEnqueueWaitForEvents(m_clCommandQueue, clEvents.size(), clEvents.data());
     if (err != CL_SUCCESS)
         WebCLException::throwException(err, es);
 }

--- a/Source/modules/webcl/WebCLContext.cpp
+++ b/Source/modules/webcl/WebCLContext.cpp
@@ -390,10 +390,9 @@ PassRefPtr<WebCLImage> WebCLContext::createImage2DBase(unsigned flags, unsigned 
     imageDescriptor.setChannelOrder(channelOrder);
     imageDescriptor.setChannelType(channelType);
     cl_image_format image_format = {channelOrder, channelType};
-    cl_image_desc desc = {CL_MEM_OBJECT_IMAGE2D, static_cast<size_t>(width), static_cast<size_t>(height), 0, 0, static_cast<size_t>(rowPitch), 0, 0, 0, 0};
 
     cl_int err = CL_SUCCESS;
-    cl_mem clMemId = clCreateImage(m_clContext, flags, &image_format, &desc, data, &err);
+    cl_mem clMemId = clCreateImage2D(m_clContext, flags, &image_format, width, height, rowPitch, data, &err);
     if (err != CL_SUCCESS) {
         WebCLException::throwException(err, es);
         return nullptr;

--- a/Source/modules/webcl/WebCLDevice.cpp
+++ b/Source/modules/webcl/WebCLDevice.cpp
@@ -17,8 +17,13 @@ namespace blink {
 
 WebCLDevice::~WebCLDevice()
 {
-    release();
-    ASSERT(!m_clDeviceId);
+    // Unlike WebCLContext / WebCLCommandQueue / WebCLProgram / ...,
+    // WebCLDevice does not need to call a release() method here:
+    // 1) OpenCL 1.1 runtime has no clReleaseDevice() or an alternative, so
+    //    there's no need to release the device.
+    // 2) The OpenCL 1.2 (or above) spec implies that clReleaseDevice() is only
+    //    meaningful for sub devices, but no sub device is created in our WebCL
+    //    1.0 implementation.
 }
 
 PassRefPtr<WebCLDevice> WebCLDevice::create(cl_device_id deviceId)
@@ -453,18 +458,6 @@ Vector<String> WebCLDevice::getSupportedExtensions()
 void WebCLDevice::getEnabledExtensions(HashSet<String>& extensions)
 {
     m_extension.getEnabledExtensions(extensions);
-}
-
-void WebCLDevice::release()
-{
-    if (isReleased())
-        return;
-
-    cl_int err = clReleaseDevice(m_clDeviceId);
-    if (err != CL_SUCCESS)
-        ASSERT_NOT_REACHED();
-
-    m_clDeviceId = 0;
 }
 
 WebCLDevice::WebCLDevice(cl_device_id device, WebCLPlatform* platform)

--- a/Source/modules/webcl/WebCLDevice.h
+++ b/Source/modules/webcl/WebCLDevice.h
@@ -40,13 +40,11 @@ public:
     unsigned getImage2DMaxHeight();
     unsigned getMaxWorkGroup();
     Vector<unsigned> getMaxWorkItem();
-    void release();
     PassRefPtr<WebCLPlatform> getPlatform() const { return m_platform; }
     cl_device_id getDeviceId() { return m_clDeviceId; }
 
 private:
     WebCLDevice(cl_device_id, WebCLPlatform* platform);
-    bool isReleased() { return !m_clDeviceId; }
 
     WebCLPlatform* m_platform;
     WebCLExtension m_extension;

--- a/Source/modules/webcl/WebCLException.cpp
+++ b/Source/modules/webcl/WebCLException.cpp
@@ -215,9 +215,6 @@ void WebCLException::throwException(int& code, ExceptionState& es)
     case CL_INVALID_PROPERTY:
         es.throwWebCLException(WebCLException::INVALID_PROPERTY, WebCLException::invalidPropertyMessage);
         break;
-    case CL_INVALID_IMAGE_DESCRIPTOR:
-        es.throwWebCLException(WebCLException::INVALID_IMAGE_FORMAT_DESCRIPTOR, WebCLException::invalidImageFormatDescriptorMessage);
-        break;
     default:
         es.throwWebCLException(WebCLException::FAILURE, WebCLException::failureMessage);
         break;

--- a/Source/modules/webcl/WebCLOpenCL.h
+++ b/Source/modules/webcl/WebCLOpenCL.h
@@ -18,14 +18,12 @@ extern cl_int (CL_API_CALL *web_clGetPlatformIDs)(cl_uint num_entries, cl_platfo
 
 extern cl_int (CL_API_CALL *web_clGetPlatformInfo)(cl_platform_id platform, cl_platform_info param_name, size_t param_value_size, void* param_value, size_t* param_value_size_ret);
 
-extern cl_int (CL_API_CALL *web_clUnloadPlatformCompiler)(cl_platform_id platform);
+extern cl_int (CL_API_CALL *web_clUnloadCompiler)(cl_platform_id platform);
 
 /* Device APIs */
 extern cl_int (CL_API_CALL *web_clGetDeviceInfo)(cl_device_id device, cl_device_info param_name, size_t param_value_size, void* param_value, size_t* param_value_size_ret);
 
 extern cl_int (CL_API_CALL *web_clGetDeviceIDs)(cl_platform_id platform, cl_device_type device_type, cl_uint num_entries, cl_device_id* devices, cl_uint* num_devices);
-
-extern cl_int (CL_API_CALL *web_clReleaseDevice)(cl_device_id device);
 
 /* Context APIs */
 extern cl_int (CL_API_CALL *web_clGetContextInfo)(cl_context context, cl_context_info param_name, size_t param_value_size, void* param_value, size_t* param_value_size_ret);
@@ -54,7 +52,7 @@ extern cl_int (CL_API_CALL *web_clReleaseMemObject)(cl_mem memobj);
 
 extern cl_int (CL_API_CALL *web_clGetImageInfo)(cl_mem image, cl_image_info param_name, size_t param_value_size, void* param_value, size_t* param_value_size_ret);
 
-extern cl_mem (CL_API_CALL *web_clCreateImage)(cl_context context, cl_mem_flags flags, const cl_image_format* image_format, const cl_image_desc* image_desc, void* host_ptr, cl_int* errcode_ret);
+extern cl_mem (CL_API_CALL *web_clCreateImage2D)(cl_context context, cl_mem_flags flags, const cl_image_format* image_format, size_t image_width, size_t image_height, size_t image_row_pitch, void* host_ptr, cl_int* errcode_ret);
 
 extern cl_int (CL_API_CALL *web_clGetSupportedImageFormats)(cl_context context, cl_mem_flags flags, cl_mem_object_type image_type, cl_uint num_entries, cl_image_format* image_formats, cl_uint* num_image_formats);
 
@@ -120,9 +118,9 @@ extern cl_int (CL_API_CALL *web_clEnqueueWriteImage)(cl_command_queue command_qu
 
 extern cl_int (CL_API_CALL *web_clEnqueueCopyBuffer)(cl_command_queue command_queue, cl_mem src_buffer, cl_mem dst_buffer, size_t src_offset, size_t dst_offset, size_t size, cl_uint num_events_in_wait_list, const cl_event* event_wait_list, cl_event* event);
 
-extern cl_int (CL_API_CALL *web_clEnqueueBarrierWithWaitList)(cl_command_queue command_queue, cl_uint num_events_in_wait_list, const cl_event* event_wait_list, cl_event* event);
+extern cl_int (CL_API_CALL *web_clEnqueueBarrier)(cl_command_queue command_queue);
 
-extern cl_int (CL_API_CALL *web_clEnqueueMarkerWithWaitList)(cl_command_queue command_queue, cl_uint num_events_in_wait_list, const cl_event* event_wait_list, cl_event* event);
+extern cl_int (CL_API_CALL *web_clEnqueueMarker)(cl_command_queue command_queue, cl_event* event);
 
 extern cl_int (CL_API_CALL *web_clEnqueueTask)(cl_command_queue command_queue, cl_kernel kernel, cl_uint num_events_in_wait_list, const cl_event* event_wait_list, cl_event* event);
 
@@ -140,6 +138,8 @@ extern cl_int (CL_API_CALL *web_clEnqueueCopyImageToBuffer)(cl_command_queue com
 
 extern cl_int (CL_API_CALL *web_clEnqueueCopyBufferToImage)(cl_command_queue command_queue, cl_mem src_buffer, cl_mem dst_image, size_t src_offset, const size_t* dst_origin, const size_t* region, cl_uint num_events_in_wait_list, const cl_event* event_wait_list, cl_event* event);
 
+extern cl_int (CL_API_CALL *web_clEnqueueWaitForEvents)(cl_command_queue command_queue, cl_uint num_events, const cl_event* event_list);
+
 /* OpenCL Extention */
 extern cl_int (CL_API_CALL *web_clEnqueueAcquireGLObjects)(cl_command_queue command_queue, cl_uint num_objects, const cl_mem* mem_objects, cl_uint num_events_in_wait_list, const cl_event* event_wait_list, cl_event* event);
 
@@ -149,7 +149,7 @@ extern cl_mem (CL_API_CALL *web_clCreateFromGLBuffer)(cl_context context, cl_mem
 
 extern cl_mem (CL_API_CALL *web_clCreateFromGLRenderbuffer)(cl_context context, cl_mem_flags flags, GLuint renderbuffer, cl_int* errcode_ret);
 
-extern cl_mem (CL_API_CALL *web_clCreateFromGLTexture)(cl_context context, cl_mem_flags flags, GLenum texture_target, GLint miplevel, GLuint texture, cl_int* errcode_ret);
+extern cl_mem (CL_API_CALL *web_clCreateFromGLTexture2D)(cl_context context, cl_mem_flags flags, GLenum texture_target, GLint miplevel, GLuint texture, cl_int* errcode_ret);
 
 extern cl_int (CL_API_CALL *web_clGetGLTextureInfo)(cl_mem, cl_gl_texture_info, size_t, void *, size_t *);
 
@@ -171,8 +171,8 @@ extern cl_int (CL_API_CALL *web_clGetGLTextureInfo)(cl_mem, cl_gl_texture_info, 
 #define clEnqueueAcquireGLObjects web_clEnqueueAcquireGLObjects
 #define clEnqueueReleaseGLObjects web_clEnqueueReleaseGLObjects
 #define clEnqueueCopyBuffer web_clEnqueueCopyBuffer
-#define clEnqueueBarrierWithWaitList web_clEnqueueBarrierWithWaitList
-#define clEnqueueMarkerWithWaitList web_clEnqueueMarkerWithWaitList
+#define clEnqueueBarrier web_clEnqueueBarrier
+#define clEnqueueMarker web_clEnqueueMarker
 #define clEnqueueTask web_clEnqueueTask
 #define clEnqueueWriteBufferRect web_clEnqueueWriteBufferRect
 #define clEnqueueReadBufferRect web_clEnqueueReadBufferRect
@@ -182,14 +182,15 @@ extern cl_int (CL_API_CALL *web_clGetGLTextureInfo)(cl_mem, cl_gl_texture_info, 
 #define clEnqueueCopyImage web_clEnqueueCopyImage
 #define clEnqueueCopyImageToBuffer web_clEnqueueCopyImageToBuffer
 #define clEnqueueCopyBufferToImage web_clEnqueueCopyBufferToImage
+#define clEnqueueWaitForEvents web_clEnqueueWaitForEvents
 #define clCreateCommandQueue web_clCreateCommandQueue
 #define clGetContextInfo web_clGetContextInfo
 #define clCreateProgramWithSource web_clCreateProgramWithSource
-#define clCreateImage web_clCreateImage
+#define clCreateImage2D web_clCreateImage2D
 #define clCreateFromGLBuffer web_clCreateFromGLBuffer
 #define clCreateFromGLRenderbuffer web_clCreateFromGLRenderbuffer
 #define clCreateSampler web_clCreateSampler
-#define clCreateFromGLTexture web_clCreateFromGLTexture
+#define clCreateFromGLTexture2D web_clCreateFromGLTexture2D
 #define clCreateUserEvent web_clCreateUserEvent
 #define clWaitForEvents web_clWaitForEvents
 #define clReleaseContext web_clReleaseContext
@@ -197,10 +198,9 @@ extern cl_int (CL_API_CALL *web_clGetGLTextureInfo)(cl_mem, cl_gl_texture_info, 
 #define clCreateContext web_clCreateContext
 #define clCreateContextFromType web_clCreateContextFromType
 #define clGetPlatformIDs web_clGetPlatformIDs
-#define clUnloadPlatformCompiler web_clUnloadPlatformCompiler
+#define clUnloadCompiler web_clUnloadCompiler
 #define clGetDeviceIDs web_clGetDeviceIDs
 #define clGetDeviceInfo web_clGetDeviceInfo
-#define clReleaseDevice web_clReleaseDevice
 #define clGetEventInfo web_clGetEventInfo
 #define clSetUserEventStatus web_clSetUserEventStatus
 #define clReleaseEvent web_clReleaseEvent

--- a/Source/modules/webcl/WebCLPlatform.cpp
+++ b/Source/modules/webcl/WebCLPlatform.cpp
@@ -16,7 +16,6 @@ namespace blink {
 
 WebCLPlatform::~WebCLPlatform()
 {
-    releaseAll();
 }
 
 PassRefPtr<WebCLPlatform> WebCLPlatform::create(cl_platform_id m_clPlatformId)
@@ -173,12 +172,6 @@ Vector<String> WebCLPlatform::getSupportedExtensions()
 void WebCLPlatform::getEnabledExtensions(HashSet<String>& extensions)
 {
     m_extension.getEnabledExtensions(extensions);
-}
-
-void WebCLPlatform::releaseAll()
-{
-    for (auto device : m_devices)
-        device->release();
 }
 
 WebCLPlatform::WebCLPlatform(cl_platform_id platform)

--- a/Source/modules/webcl/WebCLPlatform.h
+++ b/Source/modules/webcl/WebCLPlatform.h
@@ -34,7 +34,6 @@ public:
     bool enableExtension(const String& name);
     Vector<String> getSupportedExtensions();
     void getEnabledExtensions(HashSet<String>& extensions);
-    void releaseAll();
     cl_platform_id getPlatformId() { return m_clPlatformId; }
 
 private:


### PR DESCRIPTION
WebCL 1.0 is based on OpenCL 1.1, so this feature should be available as long as the device supports OpenCL 1.1 or above. This commit replaces a few OpenCL 1.2 API invocations with their counterparts in OpenCL 1.1. Since these OpenCL 1.1 APIs are still provided by the OpenCL 1.2 runtime, this commit should not break the availability of WebCL on OpenCL 1.2 devices. WebCLDevice::release() is deliberately removed since clReleaseDevice() is only available since OpenCL 1.2 to release a sub device, while it is actually not required by the WebCL 1.0 implementation.

BUG=XWALK-3975