### PR TITLE
[Android] Use RefPtr to ref the associated WebCLContext in WebCLObject.

### DIFF
--- a/Source/modules/webcl/WebCL.cpp
+++ b/Source/modules/webcl/WebCL.cpp
@@ -93,7 +93,7 @@ static void validateWebCLEventList(const Vector<RefPtr<WebCLEvent>>& events, Exc
         return;
     }
 
-    WebCLContext* referenceContext = events[0]->context();
+    WebCLContext* referenceContext = events[0]->context().get();
 
     for (auto event : events) {
         if (event->isReleased() || (event->isUserEvent() && isSyncCall)) {
@@ -102,7 +102,7 @@ static void validateWebCLEventList(const Vector<RefPtr<WebCLEvent>>& events, Exc
         }
 
         ASSERT(event->context());
-        if (!WebCLInputChecker::compareContext(event->context(), referenceContext)) {
+        if (!WebCLInputChecker::compareContext(event->context().get(), referenceContext)) {
             es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
             return;
         }

--- a/Source/modules/webcl/WebCLBuffer.cpp
+++ b/Source/modules/webcl/WebCLBuffer.cpp
@@ -29,7 +29,7 @@ WebCLBuffer::~WebCLBuffer()
 {
 }
 
-PassRefPtr<WebCLBuffer> WebCLBuffer::create(WebCLContext* context, unsigned memoryFlags, unsigned sizeInBytes, void* data, ExceptionState& es)
+PassRefPtr<WebCLBuffer> WebCLBuffer::create(PassRefPtr<WebCLContext> context, unsigned memoryFlags, unsigned sizeInBytes, void* data, ExceptionState& es)
 {
     cl_context m_clContext = context->getContext();
     if (!m_clContext) {
@@ -117,7 +117,7 @@ PassRefPtr<WebCLBuffer> WebCLBuffer::createSubBuffer(unsigned memoryFlags, unsig
     return buffer.release();
 }
 
-WebCLBuffer::WebCLBuffer(cl_mem clMem, WebCLContext* context, unsigned memoryFlags, unsigned size, WebCLBuffer* parentBuffer)
+WebCLBuffer::WebCLBuffer(cl_mem clMem, PassRefPtr<WebCLContext> context, unsigned memoryFlags, unsigned size, WebCLBuffer* parentBuffer)
     : WebCLMemoryObject(clMem, size, context, parentBuffer)
     , m_memoryFlags(memoryFlags)
 {

--- a/Source/modules/webcl/WebCLBuffer.h
+++ b/Source/modules/webcl/WebCLBuffer.h
@@ -20,13 +20,13 @@ class WebCLBuffer : public WebCLMemoryObject {
     DEFINE_WRAPPERTYPEINFO();
 public:
     ~WebCLBuffer() override;
-    static PassRefPtr<WebCLBuffer> create(WebCLContext*, unsigned, unsigned, void*, ExceptionState&);
+    static PassRefPtr<WebCLBuffer> create(PassRefPtr<WebCLContext>, unsigned, unsigned, void*, ExceptionState&);
     PassRefPtr<WebCLBuffer> createSubBuffer(unsigned, unsigned, unsigned, ExceptionState&);
 
     int type() override { return BUFFER; }
 
 private:
-    WebCLBuffer(cl_mem, WebCLContext*, unsigned, unsigned, WebCLBuffer* parentBuffer = nullptr);
+    WebCLBuffer(cl_mem, PassRefPtr<WebCLContext>, unsigned, unsigned, WebCLBuffer* parentBuffer = nullptr);
 
     unsigned m_memoryFlags;
 };

--- a/Source/modules/webcl/WebCLCommandQueue.cpp
+++ b/Source/modules/webcl/WebCLCommandQueue.cpp
@@ -43,7 +43,7 @@ WebCLCommandQueue::~WebCLCommandQueue()
     ASSERT(!m_clCommandQueue);
 }
 
-PassRefPtr<WebCLCommandQueue> WebCLCommandQueue::create(cl_command_queue commandQueue, WebCLContext* context, WebCLDevice* device)
+PassRefPtr<WebCLCommandQueue> WebCLCommandQueue::create(cl_command_queue commandQueue, PassRefPtr<WebCLContext> context, WebCLDevice* device)
 {
     return adoptRef(new WebCLCommandQueue(commandQueue, context, device));
 }
@@ -225,7 +225,7 @@ void WebCLCommandQueue::enqueueWriteBufferBase(WebCLBuffer* mem, bool blockingWr
         return;
     }
 
-    if (!WebCLInputChecker::compareContext(context(), mem->context())) {
+    if (!WebCLInputChecker::compareContext(context().get(), mem->context().get())) {
         es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
         return;
     }
@@ -260,7 +260,7 @@ void WebCLCommandQueue::enqueueWriteBuffer(WebCLBuffer* mem, bool blockingWrite,
 
 void WebCLCommandQueue::enqueueWriteBuffer(WebCLBuffer* buffer, bool blockingWrite, unsigned offset, ImageData* srcPixels, const Vector<RefPtr<WebCLEvent>>& events, WebCLEvent* event, ExceptionState& es)
 {
-    if (!isExtensionEnabled(context(), "WEBCL_html_image")) {
+    if (!isExtensionEnabled(context().get(), "WEBCL_html_image")) {
         es.throwWebCLException(WebCLException::EXTENSION_NOT_ENABLED, WebCLException::extensionNotEnabledMessage);
         return;
     }
@@ -275,7 +275,7 @@ void WebCLCommandQueue::enqueueWriteBuffer(WebCLBuffer* buffer, bool blockingWri
 
 void WebCLCommandQueue::enqueueWriteBuffer(WebCLBuffer* buffer, bool blockingWrite, unsigned offset, HTMLCanvasElement* srcCanvas, const Vector<RefPtr<WebCLEvent>>& events, WebCLEvent* event, ExceptionState& es)
 {
-    if (!isExtensionEnabled(context(), "WEBCL_html_image")) {
+    if (!isExtensionEnabled(context().get(), "WEBCL_html_image")) {
         es.throwWebCLException(WebCLException::EXTENSION_NOT_ENABLED, WebCLException::extensionNotEnabledMessage);
         return;
     }
@@ -291,7 +291,7 @@ void WebCLCommandQueue::enqueueWriteBuffer(WebCLBuffer* buffer, bool blockingWri
 
 void WebCLCommandQueue::enqueueWriteBuffer(WebCLBuffer* buffer, bool blockingWrite, unsigned offset, HTMLImageElement* srcImage, const Vector<RefPtr<WebCLEvent>>& events, WebCLEvent* event, ExceptionState& es)
 {
-    if (!isExtensionEnabled(context(), "WEBCL_html_image")) {
+    if (!isExtensionEnabled(context().get(), "WEBCL_html_image")) {
         es.throwWebCLException(WebCLException::EXTENSION_NOT_ENABLED, WebCLException::extensionNotEnabledMessage);
         return;
     }
@@ -326,7 +326,7 @@ void WebCLCommandQueue::enqueueWriteBufferRectBase(WebCLBuffer* mem, bool blocki
         return;
     }
 
-    if (!WebCLInputChecker::compareContext(context(), mem->context())) {
+    if (!WebCLInputChecker::compareContext(context().get(), mem->context().get())) {
         es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
         return;
     }
@@ -372,7 +372,7 @@ void WebCLCommandQueue::enqueueWriteBufferRect(WebCLBuffer* mem, bool blockingWr
 
 void WebCLCommandQueue::enqueueWriteBufferRect(WebCLBuffer* buffer, bool blockingWrite, const Vector<unsigned>& bufferOrigin, const Vector<unsigned>& hostOrigin, const Vector<unsigned>& region, unsigned bufferRowPitch, unsigned bufferSlicePitch, ImageData* srcPixels, const Vector<RefPtr<WebCLEvent>>& events, WebCLEvent* event, ExceptionState& es)
 {
-    if (!isExtensionEnabled(context(), "WEBCL_html_image")) {
+    if (!isExtensionEnabled(context().get(), "WEBCL_html_image")) {
         es.throwWebCLException(WebCLException::EXTENSION_NOT_ENABLED, WebCLException::extensionNotEnabledMessage);
         return;
     }
@@ -387,7 +387,7 @@ void WebCLCommandQueue::enqueueWriteBufferRect(WebCLBuffer* buffer, bool blockin
 
 void WebCLCommandQueue::enqueueWriteBufferRect(WebCLBuffer* buffer, bool blockingWrite, const Vector<unsigned>& bufferOrigin, const Vector<unsigned>& hostOrigin, const Vector<unsigned>& region, unsigned bufferRowPitch, unsigned bufferSlicePitch, HTMLCanvasElement* srcCanvas, const Vector<RefPtr<WebCLEvent>>& events, WebCLEvent* event, ExceptionState& es)
 {
-    if (!isExtensionEnabled(context(), "WEBCL_html_image")) {
+    if (!isExtensionEnabled(context().get(), "WEBCL_html_image")) {
         es.throwWebCLException(WebCLException::EXTENSION_NOT_ENABLED, WebCLException::extensionNotEnabledMessage);
         return;
     }
@@ -403,7 +403,7 @@ void WebCLCommandQueue::enqueueWriteBufferRect(WebCLBuffer* buffer, bool blockin
 
 void WebCLCommandQueue::enqueueWriteBufferRect(WebCLBuffer* buffer, bool blockingWrite, const Vector<unsigned>& bufferOrigin, const Vector<unsigned>& hostOrigin, const Vector<unsigned>& region, unsigned bufferRowPitch, unsigned bufferSlicePitch, HTMLImageElement* srcImage, const Vector<RefPtr<WebCLEvent>>& eventWaitlist, WebCLEvent* event, ExceptionState& es)
 {
-    if (!isExtensionEnabled(context(), "WEBCL_html_image")) {
+    if (!isExtensionEnabled(context().get(), "WEBCL_html_image")) {
         es.throwWebCLException(WebCLException::EXTENSION_NOT_ENABLED, WebCLException::extensionNotEnabledMessage);
         return;
     }
@@ -424,7 +424,7 @@ void WebCLCommandQueue::enqueueReadBufferBase(WebCLBuffer* mem, bool blockingRea
         return;
     }
 
-    if (!WebCLInputChecker::compareContext(context(), mem->context())) {
+    if (!WebCLInputChecker::compareContext(context().get(), mem->context().get())) {
         es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
         return;
     }
@@ -469,7 +469,7 @@ void WebCLCommandQueue::enqueueReadBuffer(WebCLBuffer* mem, bool blockingRead, u
 
 void WebCLCommandQueue::enqueueReadBuffer(WebCLBuffer* buffer, bool blockingRead, unsigned offset, unsigned numBytes, HTMLCanvasElement* dstCanvas, const Vector<RefPtr<WebCLEvent>>& events, WebCLEvent* event, ExceptionState& es)
 {
-    if (!isExtensionEnabled(context(), "WEBCL_html_image")) {
+    if (!isExtensionEnabled(context().get(), "WEBCL_html_image")) {
         es.throwWebCLException(WebCLException::EXTENSION_NOT_ENABLED, WebCLException::extensionNotEnabledMessage);
         return;
     }
@@ -490,7 +490,7 @@ void WebCLCommandQueue::enqueueReadBufferRectBase(WebCLBuffer* mem, bool blockin
         return;
     }
 
-    if (!WebCLInputChecker::compareContext(context(), mem->context())) {
+    if (!WebCLInputChecker::compareContext(context().get(), mem->context().get())) {
         es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
         return;
     }
@@ -550,7 +550,7 @@ void WebCLCommandQueue::enqueueReadBufferRect(WebCLBuffer* mem, bool blockingRea
 
 void WebCLCommandQueue::enqueueReadBufferRect(WebCLBuffer* buffer, bool blockingRead, const Vector<unsigned>& bufferOrigin, const Vector<unsigned>& hostOrigin, const Vector<unsigned>& region, unsigned bufferRowPitch, unsigned bufferSlicePitch, HTMLCanvasElement* dstCanvas, const Vector<RefPtr<WebCLEvent>>& events, WebCLEvent* event, ExceptionState& es)
 {
-    if (!isExtensionEnabled(context(), "WEBCL_html_image")) {
+    if (!isExtensionEnabled(context().get(), "WEBCL_html_image")) {
         es.throwWebCLException(WebCLException::EXTENSION_NOT_ENABLED, WebCLException::extensionNotEnabledMessage);
         return;
     }
@@ -571,7 +571,7 @@ void WebCLCommandQueue::enqueueReadImageBase(WebCLImage* image, bool blockingRea
         return;
     }
 
-    if (!WebCLInputChecker::compareContext(context(), image->context())) {
+    if (!WebCLInputChecker::compareContext(context().get(), image->context().get())) {
         es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
         return;
     }
@@ -628,7 +628,7 @@ void WebCLCommandQueue::enqueueReadImage(WebCLImage* image, bool blockingRead, c
 
 void WebCLCommandQueue::enqueueReadImage(WebCLImage* image, bool blockingRead, const Vector<unsigned>& origin, const Vector<unsigned>& region, HTMLCanvasElement* dstCanvas, const Vector<RefPtr<WebCLEvent>>& events, WebCLEvent* event, ExceptionState& es)
 {
-    if (!isExtensionEnabled(context(), "WEBCL_html_image")) {
+    if (!isExtensionEnabled(context().get(), "WEBCL_html_image")) {
         es.throwWebCLException(WebCLException::EXTENSION_NOT_ENABLED, WebCLException::extensionNotEnabledMessage);
         return;
     }
@@ -658,7 +658,7 @@ void WebCLCommandQueue::enqueueNDRangeKernel(WebCLKernel* kernel, unsigned dim, 
         }
     }
 
-    if (!WebCLInputChecker::compareContext(context(), kernel->context())) {
+    if (!WebCLInputChecker::compareContext(context().get(), kernel->context().get())) {
         es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
         return;
     }
@@ -769,7 +769,7 @@ void WebCLCommandQueue::enqueueWriteImageBase(WebCLImage* image, bool blockingWr
         }
     }
 
-    if (!WebCLInputChecker::compareContext(context(), image->context())) {
+    if (!WebCLInputChecker::compareContext(context().get(), image->context().get())) {
         es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
         return;
     }
@@ -822,7 +822,7 @@ void WebCLCommandQueue::enqueueWriteImage(WebCLImage* image, bool blockingWrite,
 
 void WebCLCommandQueue::enqueueWriteImage(WebCLImage* image, bool blockingWrite, const Vector<unsigned>& origin, const Vector<unsigned>& region, ImageData* srcPixels, const Vector<RefPtr<WebCLEvent>>& events, WebCLEvent* event, ExceptionState& es)
 {
-    if (!isExtensionEnabled(context(), "WEBCL_html_image")) {
+    if (!isExtensionEnabled(context().get(), "WEBCL_html_image")) {
         es.throwWebCLException(WebCLException::EXTENSION_NOT_ENABLED, WebCLException::extensionNotEnabledMessage);
         return;
     }
@@ -837,7 +837,7 @@ void WebCLCommandQueue::enqueueWriteImage(WebCLImage* image, bool blockingWrite,
 
 void WebCLCommandQueue::enqueueWriteImage(WebCLImage* image, bool blockingWrite, const Vector<unsigned>& origin, const Vector<unsigned>& region, HTMLCanvasElement* srcCanvas, const Vector<RefPtr<WebCLEvent>>& events, WebCLEvent* event, ExceptionState& es)
 {
-    if (!isExtensionEnabled(context(), "WEBCL_html_image")) {
+    if (!isExtensionEnabled(context().get(), "WEBCL_html_image")) {
         es.throwWebCLException(WebCLException::EXTENSION_NOT_ENABLED, WebCLException::extensionNotEnabledMessage);
         return;
     }
@@ -853,7 +853,7 @@ void WebCLCommandQueue::enqueueWriteImage(WebCLImage* image, bool blockingWrite,
 
 void WebCLCommandQueue::enqueueWriteImage(WebCLImage* image, bool blockingWrite, const Vector<unsigned>& origin, const Vector<unsigned>& region, HTMLImageElement* srcImage, const Vector<RefPtr<WebCLEvent>>& events, WebCLEvent* event, ExceptionState& es)
 {
-    if (!isExtensionEnabled(context(), "WEBCL_html_image")) {
+    if (!isExtensionEnabled(context().get(), "WEBCL_html_image")) {
         es.throwWebCLException(WebCLException::EXTENSION_NOT_ENABLED, WebCLException::extensionNotEnabledMessage);
         return;
     }
@@ -869,7 +869,7 @@ void WebCLCommandQueue::enqueueWriteImage(WebCLImage* image, bool blockingWrite,
 
 void WebCLCommandQueue::enqueueWriteImage(WebCLImage* image, bool blockingWrite, HTMLVideoElement* srcVideo, const Vector<RefPtr<WebCLEvent>>& events, WebCLEvent* event, ExceptionState& es)
 {
-    if (!isExtensionEnabled(context(), "WEBCL_html_video")) {
+    if (!isExtensionEnabled(context().get(), "WEBCL_html_video")) {
         es.throwWebCLException(WebCLException::EXTENSION_NOT_ENABLED, WebCLException::extensionNotEnabledMessage);
         return;
     }
@@ -918,7 +918,7 @@ void WebCLCommandQueue::enqueueCopyBuffer(WebCLBuffer* srcBuffer, WebCLBuffer* d
         }
     }
 
-    if (!WebCLInputChecker::compareContext(context(), srcBuffer->context()) || !WebCLInputChecker::compareContext(context(), dstBuffer->context())) {
+    if (!WebCLInputChecker::compareContext(context().get(), srcBuffer->context().get()) || !WebCLInputChecker::compareContext(context().get(), dstBuffer->context().get())) {
         es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
         return;
     }
@@ -973,7 +973,7 @@ void WebCLCommandQueue::enqueueCopyBufferRect(WebCLBuffer* srcBuffer, WebCLBuffe
         }
     }
 
-    if (!WebCLInputChecker::compareContext(context(), srcBuffer->context()) || !WebCLInputChecker::compareContext(context(), dstBuffer->context())) {
+    if (!WebCLInputChecker::compareContext(context().get(), srcBuffer->context().get()) || !WebCLInputChecker::compareContext(context().get(), dstBuffer->context().get())) {
         es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
         return;
     }
@@ -1040,7 +1040,7 @@ void WebCLCommandQueue::enqueueCopyImage(WebCLImage* srcImage, WebCLImage* dstIm
         }
     }
 
-    if (!WebCLInputChecker::compareContext(context(), srcImage->context()) || !WebCLInputChecker::compareContext(context(), dstImage->context())) {
+    if (!WebCLInputChecker::compareContext(context().get(), srcImage->context().get()) || !WebCLInputChecker::compareContext(context().get(), dstImage->context().get())) {
         es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
         return;
     }
@@ -1109,7 +1109,7 @@ void WebCLCommandQueue::enqueueCopyImageToBuffer(WebCLImage* srcImage, WebCLBuff
         }
     }
 
-    if (!WebCLInputChecker::compareContext(context(), srcImage->context()) || !WebCLInputChecker::compareContext(context(), dstBuffer->context())) {
+    if (!WebCLInputChecker::compareContext(context().get(), srcImage->context().get()) || !WebCLInputChecker::compareContext(context().get(), dstBuffer->context().get())) {
         es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
         return;
     }
@@ -1169,7 +1169,7 @@ void WebCLCommandQueue::enqueueCopyBufferToImage(WebCLBuffer* srcBuffer, WebCLIm
         }
     }
 
-    if (!WebCLInputChecker::compareContext(context(), srcBuffer->context()) || !WebCLInputChecker::compareContext(context(), dstImage->context())) {
+    if (!WebCLInputChecker::compareContext(context().get(), srcBuffer->context().get()) || !WebCLInputChecker::compareContext(context().get(), dstImage->context().get())) {
         es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
         return;
     }
@@ -1205,7 +1205,7 @@ void WebCLCommandQueue::enqueueCopyBufferToImage(WebCLBuffer* srcBuffer, WebCLIm
         WebCLException::throwException(err, es);
 }
 
-WebCLCommandQueue::WebCLCommandQueue(cl_command_queue commandQueue, WebCLContext* context, WebCLDevice* device)
+WebCLCommandQueue::WebCLCommandQueue(cl_command_queue commandQueue, PassRefPtr<WebCLContext> context, WebCLDevice* device)
     : WebCLObject(context)
     , m_whenFinishCallback(nullptr)
     , m_eventForCallback(0)
@@ -1222,7 +1222,7 @@ Vector<cl_event> WebCLCommandQueue::WebCLEventVectorToCLEventVector(bool blockin
             es.throwWebCLException(WebCLException::INVALID_EVENT_WAIT_LIST, WebCLException::invalidEventWaitListMessage);
             break;
         }
-        if (!WebCLInputChecker::compareContext(context(), event->context())) {
+        if (!WebCLInputChecker::compareContext(context().get(), event->context().get())) {
             es.throwWebCLException(WebCLException::INVALID_CONTEXT, WebCLException::invalidContextMessage);
             break;
         }

--- a/Source/modules/webcl/WebCLCommandQueue.h
+++ b/Source/modules/webcl/WebCLCommandQueue.h
@@ -38,7 +38,7 @@ class WebCLCommandQueue : public WebCLObject, public ScriptWrappable {
     DEFINE_WRAPPERTYPEINFO();
 public:
     ~WebCLCommandQueue() override;
-    static PassRefPtr<WebCLCommandQueue> create(cl_command_queue, WebCLContext*, WebCLDevice*);
+    static PassRefPtr<WebCLCommandQueue> create(cl_command_queue, PassRefPtr<WebCLContext>, WebCLDevice*);
 
     ScriptValue getInfo(ScriptState*, int, ExceptionState&);
     void enqueueWriteBuffer(WebCLBuffer*, bool, unsigned, unsigned, DOMArrayBufferView*, const Vector<RefPtr<WebCLEvent>>&, WebCLEvent*, ExceptionState&);
@@ -96,7 +96,7 @@ private:
     void enqueueReadImageBase(WebCLImage*, bool, const Vector<unsigned>&, const Vector<unsigned>&, unsigned, void*, size_t, const Vector<RefPtr<WebCLEvent>>&, WebCLEvent*, ExceptionState&);
     void enqueueWriteBufferRectBase(WebCLBuffer*, bool, const Vector<unsigned>&, const Vector<unsigned>&, const Vector<unsigned>&, unsigned, unsigned, unsigned, unsigned, void*, size_t, const Vector<RefPtr<WebCLEvent>>&, WebCLEvent*, ExceptionState&);
     void enqueueWriteImageBase(WebCLImage*, bool, const Vector<unsigned>&, const Vector<unsigned>&, unsigned, void*, size_t, const Vector<RefPtr<WebCLEvent>>&, WebCLEvent*, ExceptionState&);
-    WebCLCommandQueue(cl_command_queue, WebCLContext*, WebCLDevice*);
+    WebCLCommandQueue(cl_command_queue, PassRefPtr<WebCLContext>, WebCLDevice*);
     Vector<cl_event> WebCLEventVectorToCLEventVector(bool, Vector<RefPtr<WebCLEvent>>, ExceptionState&);
     cl_event* WebCLEventPtrToCLEventPtr(WebCLEvent*, ExceptionState&);
     bool isExtensionEnabled(WebCLContext*, const String& name) const;

--- a/Source/modules/webcl/WebCLImage.cpp
+++ b/Source/modules/webcl/WebCLImage.cpp
@@ -18,7 +18,7 @@ WebCLImage::~WebCLImage()
 {
 }
 
-PassRefPtr<WebCLImage> WebCLImage::create(cl_mem image, const WebCLImageDescriptor& imageDescriptor, WebCLContext* context)
+PassRefPtr<WebCLImage> WebCLImage::create(cl_mem image, const WebCLImageDescriptor& imageDescriptor, PassRefPtr<WebCLContext> context)
 {
     return adoptRef(new WebCLImage(image, imageDescriptor, context));
 }
@@ -37,7 +37,7 @@ void WebCLImage::getInfo(ExceptionState& es, WebCLImageDescriptor& descriptor)
     descriptor.setChannelType(m_imageDescriptor.channelType());
 }
 
-WebCLImage::WebCLImage(cl_mem image, const WebCLImageDescriptor& imageDescriptor, WebCLContext* context)
+WebCLImage::WebCLImage(cl_mem image, const WebCLImageDescriptor& imageDescriptor, PassRefPtr<WebCLContext> context)
     : WebCLMemoryObject(image, 0, context)
     , m_imageDescriptor(imageDescriptor)
 {

--- a/Source/modules/webcl/WebCLImage.h
+++ b/Source/modules/webcl/WebCLImage.h
@@ -23,14 +23,14 @@ class WebCLImage : public WebCLMemoryObject {
     DEFINE_WRAPPERTYPEINFO();
 public:
     ~WebCLImage() override;
-    static PassRefPtr<WebCLImage> create(cl_mem, const WebCLImageDescriptor&, WebCLContext*);
+    static PassRefPtr<WebCLImage> create(cl_mem, const WebCLImageDescriptor&, PassRefPtr<WebCLContext>);
 
     void getInfo(ExceptionState&, WebCLImageDescriptor&);
     const WebCLImageDescriptor& imageDescriptor() { return m_imageDescriptor; }
     int type() override { return IMAGE; }
 
 private:
-    WebCLImage(cl_mem, const WebCLImageDescriptor&, WebCLContext*);
+    WebCLImage(cl_mem, const WebCLImageDescriptor&, PassRefPtr<WebCLContext>);
 
     WebCLImageDescriptor m_imageDescriptor;
 };

--- a/Source/modules/webcl/WebCLKernel.cpp
+++ b/Source/modules/webcl/WebCLKernel.cpp
@@ -30,7 +30,7 @@ WebCLKernel::~WebCLKernel()
     ASSERT(!m_clKernel);
 }
 
-PassRefPtr<WebCLKernel> WebCLKernel::create(cl_kernel kernel, WebCLContext* context, WebCLProgram* program, const String& kernelName)
+PassRefPtr<WebCLKernel> WebCLKernel::create(cl_kernel kernel, PassRefPtr<WebCLContext> context, WebCLProgram* program, const String& kernelName)
 {
     return adoptRef(new WebCLKernel(kernel, context, program, kernelName));
 }
@@ -435,7 +435,7 @@ unsigned WebCLKernel::associatedArguments()
     return count;
 }
 
-WebCLKernel::WebCLKernel(cl_kernel kernel, WebCLContext* context, WebCLProgram* program, const String& kernelName)
+WebCLKernel::WebCLKernel(cl_kernel kernel, PassRefPtr<WebCLContext> context, WebCLProgram* program, const String& kernelName)
     : WebCLObject(context)
     , m_program(program)
     , m_kernelName(kernelName)

--- a/Source/modules/webcl/WebCLKernel.h
+++ b/Source/modules/webcl/WebCLKernel.h
@@ -29,7 +29,7 @@ class WebCLKernel : public WebCLObject, public ScriptWrappable {
     DEFINE_WRAPPERTYPEINFO();
 public:
     ~WebCLKernel() override;
-    static PassRefPtr<WebCLKernel> create(cl_kernel, WebCLContext*, WebCLProgram*, const String&);
+    static PassRefPtr<WebCLKernel> create(cl_kernel, PassRefPtr<WebCLContext>, WebCLProgram*, const String&);
 
     ScriptValue getInfo(ScriptState*, int, ExceptionState&);
     ScriptValue getWorkGroupInfo(ScriptState*, WebCLDevice*, int, ExceptionState&);
@@ -49,7 +49,7 @@ public:
     cl_kernel getKernel() const { return m_clKernel; }
 
 private:
-    WebCLKernel(cl_kernel, WebCLContext*, WebCLProgram*, const String&);
+    WebCLKernel(cl_kernel, PassRefPtr<WebCLContext>, WebCLProgram*, const String&);
     bool isReleased() const { return !m_clKernel; }
 
     WebCLProgram* m_program;

--- a/Source/modules/webcl/WebCLMemoryObject.cpp
+++ b/Source/modules/webcl/WebCLMemoryObject.cpp
@@ -21,7 +21,7 @@ WebCLMemoryObject::~WebCLMemoryObject()
     ASSERT(!m_clMem);
 }
 
-PassRefPtr<WebCLMemoryObject> WebCLMemoryObject::create(cl_mem mem, unsigned sizeInBytes, WebCLContext* context)
+PassRefPtr<WebCLMemoryObject> WebCLMemoryObject::create(cl_mem mem, unsigned sizeInBytes, PassRefPtr<WebCLContext> context)
 {
     return adoptRef(new WebCLMemoryObject(mem, sizeInBytes, context));
 }
@@ -91,7 +91,7 @@ void WebCLMemoryObject::release()
     m_clMem = 0;
 }
 
-WebCLMemoryObject::WebCLMemoryObject(cl_mem mem, unsigned sizeInBytes, WebCLContext* context, WebCLMemoryObject* parentBuffer)
+WebCLMemoryObject::WebCLMemoryObject(cl_mem mem, unsigned sizeInBytes, PassRefPtr<WebCLContext> context, WebCLMemoryObject* parentBuffer)
     : WebCLObject(context)
     , m_parentMemObject(parentBuffer)
     , m_sizeInBytes(sizeInBytes)

--- a/Source/modules/webcl/WebCLMemoryObject.h
+++ b/Source/modules/webcl/WebCLMemoryObject.h
@@ -29,7 +29,7 @@ public:
     };
 
     ~WebCLMemoryObject() override;
-    static PassRefPtr<WebCLMemoryObject> create(cl_mem, unsigned, WebCLContext*);
+    static PassRefPtr<WebCLMemoryObject> create(cl_mem, unsigned, PassRefPtr<WebCLContext>);
 
     virtual ScriptValue getInfo(ScriptState*, int, ExceptionState&);
     void release() override;
@@ -40,7 +40,7 @@ public:
     bool isReleased() const { return !m_clMem; }
 
 protected:
-    WebCLMemoryObject(cl_mem, unsigned, WebCLContext*, WebCLMemoryObject* parentBuffer = nullptr);
+    WebCLMemoryObject(cl_mem, unsigned, PassRefPtr<WebCLContext>, WebCLMemoryObject* parentBuffer = nullptr);
 
     WebCLMemoryObject* m_parentMemObject;
     size_t m_sizeInBytes;

--- a/Source/modules/webcl/WebCLObject.cpp
+++ b/Source/modules/webcl/WebCLObject.cpp
@@ -16,7 +16,7 @@ WebCLObject::~WebCLObject()
         m_context->untrackReleaseableWebCLObject(createWeakPtr());
 }
 
-WebCLObject::WebCLObject(WebCLContext* context)
+WebCLObject::WebCLObject(PassRefPtr<WebCLContext> context)
     : m_weakFactory(this)
     , m_context(context)
 {
@@ -30,13 +30,13 @@ WebCLObject::WebCLObject()
 {
 }
 
-WebCLContext* WebCLObject::context()
+PassRefPtr<WebCLContext> WebCLObject::context()
 {
     ASSERT(m_context);
     return m_context;
 }
 
-void WebCLObject::setContext(WebCLContext* context)
+void WebCLObject::setContext(PassRefPtr<WebCLContext> context)
 {
     m_context = context;
     m_context->trackReleaseableWebCLObject(createWeakPtr());

--- a/Source/modules/webcl/WebCLObject.h
+++ b/Source/modules/webcl/WebCLObject.h
@@ -10,7 +10,9 @@
 
 #include "modules/webcl/WebCLException.h"
 
+#include <wtf/PassRefPtr.h>
 #include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace blink {
@@ -24,19 +26,19 @@ class WebCLObject : public RefCounted<WebCLObject> {
 public:
     virtual ~WebCLObject();
     WeakPtr<WebCLObject> createWeakPtr() { return m_weakFactory.createWeakPtr(); }
-    WebCLContext* context();
+    PassRefPtr<WebCLContext> context();
 
-    void setContext(WebCLContext* context);
+    void setContext(PassRefPtr<WebCLContext> context);
     virtual void release() { ASSERT_NOT_REACHED(); }
 
 protected:
-    explicit WebCLObject(WebCLContext* context);
+    explicit WebCLObject(PassRefPtr<WebCLContext> context);
     // Some object isn't associated with WebContext in constructor by developer.
     // but at runtime by OpenCL. Such as: WebCLEvent
     WebCLObject();
 
     WeakPtrFactory<WebCLObject> m_weakFactory;
-    WebCLContext* m_context;
+    RefPtr<WebCLContext> m_context;
 };
 
 } // namespace blink

--- a/Source/modules/webcl/WebCLProgram.cpp
+++ b/Source/modules/webcl/WebCLProgram.cpp
@@ -36,7 +36,7 @@ WebCLProgram::~WebCLProgram()
     ASSERT(!m_clProgram);
 }
 
-PassRefPtr<WebCLProgram> WebCLProgram::create(cl_program program, WebCLContext* context, const String& kernelSource)
+PassRefPtr<WebCLProgram> WebCLProgram::create(cl_program program, PassRefPtr<WebCLContext> context, const String& kernelSource)
 {
     return adoptRef(new WebCLProgram(program, context, kernelSource));
 }
@@ -459,7 +459,7 @@ const String& WebCLProgram::sourceWithCommentsStripped()
     return m_programSourceWithCommentsStripped;
 }
 
-WebCLProgram::WebCLProgram(cl_program program, WebCLContext* context, const String& kernelSource)
+WebCLProgram::WebCLProgram(cl_program program, PassRefPtr<WebCLContext> context, const String& kernelSource)
     : WebCLObject(context)
     , m_buildCallback(nullptr)
     , m_programSource(kernelSource)

--- a/Source/modules/webcl/WebCLProgram.h
+++ b/Source/modules/webcl/WebCLProgram.h
@@ -28,7 +28,7 @@ class WebCLProgram : public WebCLObject, public ScriptWrappable {
     DEFINE_WRAPPERTYPEINFO();
 public:
     ~WebCLProgram() override;
-    static PassRefPtr<WebCLProgram> create(cl_program, WebCLContext*, const String&);
+    static PassRefPtr<WebCLProgram> create(cl_program, PassRefPtr<WebCLContext>, const String&);
 
     ScriptValue getInfo(ScriptState*, int, ExceptionState&);
     ScriptValue getBuildInfo(ScriptState* scriptState, WebCLDevice*, int, ExceptionState&);
@@ -42,7 +42,7 @@ public:
     const String& getProgramSource() const { return m_programSource; }
 
 private:
-    WebCLProgram(cl_program, WebCLContext*, const String&);
+    WebCLProgram(cl_program, PassRefPtr<WebCLContext>, const String&);
     bool isReleased() const { return !m_clProgram; }
     bool isExtensionEnabled(RefPtr<blink::WebCLContext>, const String&);
     typedef void (*pfnNotify)(cl_program, void*);

--- a/Source/modules/webcl/WebCLSampler.cpp
+++ b/Source/modules/webcl/WebCLSampler.cpp
@@ -20,7 +20,7 @@ WebCLSampler::~WebCLSampler()
     ASSERT(!m_clSampler);
 }
 
-PassRefPtr<WebCLSampler> WebCLSampler::create(cl_sampler sampler, bool normCoords, unsigned addressingMode, unsigned filterMode, WebCLContext* context)
+PassRefPtr<WebCLSampler> WebCLSampler::create(cl_sampler sampler, bool normCoords, unsigned addressingMode, unsigned filterMode, PassRefPtr<WebCLContext> context)
 {
     return adoptRef(new WebCLSampler(sampler, normCoords, addressingMode, filterMode, context));
 }
@@ -68,7 +68,7 @@ void WebCLSampler::release()
     m_clSampler = 0;
 }
 
-WebCLSampler::WebCLSampler(cl_sampler sampler, bool normCoords, unsigned addressingMode, unsigned filterMode, WebCLContext* context)
+WebCLSampler::WebCLSampler(cl_sampler sampler, bool normCoords, unsigned addressingMode, unsigned filterMode, PassRefPtr<WebCLContext> context)
     : WebCLObject(context)
     , m_normCoords(normCoords)
     , m_addressingMode(addressingMode)

--- a/Source/modules/webcl/WebCLSampler.h
+++ b/Source/modules/webcl/WebCLSampler.h
@@ -21,7 +21,7 @@ class WebCLSampler : public WebCLObject, public ScriptWrappable {
     DEFINE_WRAPPERTYPEINFO();
 public:
     ~WebCLSampler() override;
-    static PassRefPtr<WebCLSampler> create(cl_sampler, bool, unsigned, unsigned, WebCLContext*);
+    static PassRefPtr<WebCLSampler> create(cl_sampler, bool, unsigned, unsigned, PassRefPtr<WebCLContext>);
 
     ScriptValue getInfo(ScriptState*, cl_sampler_info, ExceptionState&);
     void release() override;
@@ -29,7 +29,7 @@ public:
     cl_sampler getSampler() const { return m_clSampler; }
 
 private:
-    WebCLSampler(cl_sampler, bool, unsigned, unsigned, WebCLContext*);
+    WebCLSampler(cl_sampler, bool, unsigned, unsigned, PassRefPtr<WebCLContext>);
     bool isReleased() const { return !m_clSampler; }
 
     bool m_normCoords;

--- a/Source/modules/webcl/WebCLUserEvent.cpp
+++ b/Source/modules/webcl/WebCLUserEvent.cpp
@@ -19,7 +19,7 @@ WebCLUserEvent::~WebCLUserEvent()
 {
 }
 
-PassRefPtr<WebCLUserEvent> WebCLUserEvent::create(WebCLContext* context, ExceptionState& es)
+PassRefPtr<WebCLUserEvent> WebCLUserEvent::create(PassRefPtr<WebCLContext> context, ExceptionState& es)
 {
     cl_int userEventError = 0;
     cl_event userEvent = clCreateUserEvent(context->getContext(), &userEventError);
@@ -77,7 +77,7 @@ ScriptValue WebCLUserEvent::getInfo(ScriptState* scriptState, unsigned name, Exc
     return WebCLEvent::getInfo(scriptState, name, es);
 }
 
-WebCLUserEvent::WebCLUserEvent(cl_event event, WebCLContext* context)
+WebCLUserEvent::WebCLUserEvent(cl_event event, PassRefPtr<WebCLContext> context)
     : WebCLEvent(event)
     , m_eventStatusSituation(StatusUnset)
     , m_executionStatus(0)

--- a/Source/modules/webcl/WebCLUserEvent.h
+++ b/Source/modules/webcl/WebCLUserEvent.h
@@ -9,6 +9,7 @@
 #if ENABLE(WEBCL)
 #include "modules/webcl/WebCLConfig.h"
 #include "modules/webcl/WebCLEvent.h"
+#include "wtf/PassRefPtr.h"
 
 namespace blink {
 
@@ -18,7 +19,7 @@ class WebCLUserEvent : public WebCLEvent {
     DEFINE_WRAPPERTYPEINFO();
 public:
     ~WebCLUserEvent() override;
-    static PassRefPtr<WebCLUserEvent> create(WebCLContext*, ExceptionState&);
+    static PassRefPtr<WebCLUserEvent> create(PassRefPtr<WebCLContext>, ExceptionState&);
 
     void setStatus(cl_int, ExceptionState&);
     ScriptValue getInfo(ScriptState* scriptState, unsigned, ExceptionState&) override;
@@ -28,7 +29,7 @@ public:
     int getStatus() override { return m_executionStatus; }
 
 private:
-    WebCLUserEvent(cl_event event, WebCLContext*);
+    WebCLUserEvent(cl_event event, PassRefPtr<WebCLContext>);
     enum EventStatusSituation m_eventStatusSituation;
     int m_executionStatus;
 };


### PR DESCRIPTION
See the commit message for more details. This is a temporary fix before the transition to Oilpan.