### PR TITLE
Exclude media player's resources if use minimum resources

### DIFF
--- a/public/blink_image_resources.grd
+++ b/public/blink_image_resources.grd
@@ -10,6 +10,7 @@
   <release seq="1">
     <structures fallback_to_low_resolution="true">
       <structure type="chrome_scaled_image" name="IDR_BROKENIMAGE" file="blink/broken_image.png" />
+      <if expr="not pp_ifdef('use_minimum_resources')">
       <structure type="chrome_scaled_image" name="IDR_MEDIAPLAYER_PAUSE_BUTTON" file="blink/mediaplayer_pause.png" />
       <structure type="chrome_scaled_image" name="IDR_MEDIAPLAYER_PAUSE_BUTTON_HOVER" file="blink/mediaplayer_pause_hover.png" />
       <structure type="chrome_scaled_image" name="IDR_MEDIAPLAYER_PAUSE_BUTTON_DOWN" file="blink/mediaplayer_pause_down.png" />
@@ -49,6 +50,7 @@
       <structure type="chrome_scaled_image" name="IDR_MEDIAPLAYER_CAST_BUTTON_ON" file="blink/mediaplayer_cast_on.png" />
       <structure type="chrome_scaled_image" name="IDR_MEDIAPLAYER_OVERLAY_CAST_BUTTON_OFF" file="blink/mediaplayer_overlay_cast_off.png" />
       <structure type="chrome_scaled_image" name="IDR_MEDIAPLAYER_OVERLAY_PLAY_BUTTON" file="blink/mediaplayer_overlay_play.png" />
+      </if>
       <structure type="chrome_scaled_image" name="IDR_PAN_SCROLL_ICON" file="blink/pan_icon.png" />
       <structure type="chrome_scaled_image" name="IDR_SEARCH_CANCEL" file="blink/search_cancel.png" />
       <structure type="chrome_scaled_image" name="IDR_SEARCH_CANCEL_PRESSED" file="blink/search_cancel_pressed.png" />


### PR DESCRIPTION
Exclude media player's resources for the flag use_minimum_resources.

This patch is the backport from Crosswalk-lite
