### PR TITLE
Extending protocol.json by stackEntryLine which is used for total time annotations in CPU profiling

### DIFF
--- a/Source/core/inspector/ScriptProfile.cpp
+++ b/Source/core/inspector/ScriptProfile.cpp
@@ -105,6 +105,7 @@ static PassRefPtr<TypeBuilder::Profiler::CPUProfileNode> buildInspectorObjectFor
         .setColumnNumber(node->GetColumnNumber())
         .setHitCount(node->GetHitCount())
         .setCallUID(node->GetCallUid())
+        .setStackEntryLine(node->GetSrcLine())
         .setChildren(children.release())
         .setPositionTicks(positionTicks.release())
         .setDeoptReason(node->GetBailoutReason())

--- a/Source/devtools/protocol.json
+++ b/Source/devtools/protocol.json
@@ -3879,6 +3879,7 @@
                     { "name": "columnNumber", "type": "integer", "description": "1-based column number of the function start position." },
                     { "name": "hitCount", "type": "integer", "description": "Number of samples where this node was on top of the call stack." },
                     { "name": "callUID", "type": "number", "description": "Call UID." },
+                    { "name": "stackEntryLine", "type": "integer", "description": "Hit line for entry in stack." },
                     { "name": "children", "type": "array", "items": { "$ref": "CPUProfileNode" }, "description": "Child nodes." },
                     { "name": "deoptReason", "type": "string", "description": "The reason of being not optimized. The function may be deoptimized or marked as don't optimize."},
                     { "name": "id", "type": "integer", "description": "Unique id of the node." },


### PR DESCRIPTION
This is the second part of patch for CPU Profile feature - annotation of source lines by total time.
The first can be viewed at this link:
https://github.com/crosswalk-project/v8-crosswalk/pull/107.
These changes is needed to transmit to the frontend source lines from StackEntries, which are stored in the ProfileNodes.