### PR TITLE
To disable Web Speech

### DIFF
--- a/Source/modules/modules_gypi_generator.py
+++ b/Source/modules/modules_gypi_generator.py
@@ -1,3 +1,10 @@
+#!/usr/bin/python
+import os
+import sys
+
+###########################################
+def file_header():
+    str = """
 {
   'includes': [
     '../core/core_generated.gypi',
@@ -11,6 +18,13 @@
     # ways.
     'extra_blink_module_idl_files': [],
     'extra_blink_module_files': [],
+    """
+    return str
+
+###########################################end file_header
+
+def modules_idl_files():
+    str = """
     # Files for which bindings (.cpp and .h files) will be generated
     'modules_idl_files': [
       '<@(extra_blink_module_idl_files)',
@@ -164,6 +178,9 @@
       'serviceworkers/ServiceWorkerGlobalScope.idl',
       'serviceworkers/ServiceWorkerRegistration.idl',
       'serviceworkers/WindowClient.idl',
+    """
+
+    str_speech = """
       'speech/SpeechGrammar.idl',
       'speech/SpeechGrammarList.idl',
       'speech/SpeechRecognition.idl',
@@ -176,6 +193,9 @@
       'speech/SpeechSynthesisEvent.idl',
       'speech/SpeechSynthesisUtterance.idl',
       'speech/SpeechSynthesisVoice.idl',
+    """
+
+    str_tail = """
       'storage/Storage.idl',
       'storage/StorageEvent.idl',
       'vr/HMDVRDevice.idl',
@@ -250,6 +270,17 @@
       'webcl/WebCLSampler.idl',
       'webcl/WebCLUserEvent.idl'
     ],
+    """
+
+    if not disable_speech:
+        str = str + str_speech
+
+    return str + str_tail
+####################################end modules_idl_files
+
+
+def modules_dependency_idl_files():
+    str = """
     # 'partial interface' or target (right side of) 'implements'
     'modules_dependency_idl_files': [
       'background_sync/ServiceWorkerGlobalScopeSync.idl',
@@ -307,8 +338,14 @@
       'serviceworkers/NavigatorServiceWorker.idl',
       'serviceworkers/WindowCacheStorage.idl',
       'serviceworkers/WorkerCacheStorage.idl',
+    """
+
+    str_speech = """
       'speech/WindowSpeech.idl',
       'speech/WindowSpeechSynthesis.idl',
+    """
+
+    str_tail = """
       'storage/WindowStorage.idl',
       'vibration/NavigatorVibration.idl',
       'vr/NavigatorVRDevice.idl',
@@ -317,6 +354,16 @@
       'webdatabase/WindowWebDatabase.idl',
       'webmidi/NavigatorWebMIDI.idl',
     ],
+    """
+
+    if not disable_speech:
+        str = str + str_speech
+
+    return str + str_tail
+####################################end modules_dependency_idl_files
+
+def modules_event_idl_files():
+    str = """
     # interfaces that inherit from Event
     'modules_event_idl_files': [
       'app_banner/BeforeInstallPromptEvent.idl',
@@ -342,9 +389,15 @@
       'serviceworkers/ExtendableEvent.idl',
       'serviceworkers/FetchEvent.idl',
       'serviceworkers/InstallEvent.idl',
+    """
+
+    str_speech = """
       'speech/SpeechRecognitionError.idl',
       'speech/SpeechRecognitionEvent.idl',
       'speech/SpeechSynthesisEvent.idl',
+    """
+
+    str_tail = """
       'storage/StorageEvent.idl',
       'webaudio/AudioProcessingEvent.idl',
       'webaudio/OfflineAudioCompletionEvent.idl',
@@ -352,6 +405,17 @@
       'webmidi/MIDIMessageEvent.idl',
       'websockets/CloseEvent.idl',
     ],
+    """
+
+    if not disable_speech:
+        str = str + str_speech
+
+    return str + str_tail
+####################################end modules_event_idl_files
+
+
+def modules_dictionary_idl_files():
+    str = """
     'modules_dictionary_idl_files': [
       'app_banner/BeforeInstallPromptEventInit.idl',
       'background_sync/SyncEventInit.idl',
@@ -388,8 +452,14 @@
       'serviceworkers/ExtendableEventInit.idl',
       'serviceworkers/InstallEventInit.idl',
       'serviceworkers/RegistrationOptions.idl',
+    """
+
+    str_speech = """
       'speech/SpeechRecognitionErrorInit.idl',
       'speech/SpeechRecognitionEventInit.idl',
+    """
+
+    str_tail = """
       'storage/StorageEventInit.idl',
       'vr/VRFieldOfViewInit.idl',
       'webcl/WebCLImageDescriptor.idl',
@@ -398,6 +468,16 @@
       'webmidi/MIDIOptions.idl',
       'websockets/CloseEventInit.idl',
     ],
+    """
+
+    if not disable_speech:
+        str = str + str_speech
+
+    return str + str_tail
+####################################end modules_dictionary_idl_files
+
+def generated_modules_files():
+    str = """
     'generated_modules_files': [
       # .cpp files from make_modules_generated actions.
       '<(blink_modules_output_dir)/EventModules.cpp',
@@ -409,6 +489,13 @@
       '<(blink_modules_output_dir)/IndexedDBNames.cpp',
       '<(blink_modules_output_dir)/IndexedDBNames.h',
     ],
+    """
+
+    return str
+####################################end generated_modules_files
+
+def generated_modules_dictionary_files():
+    str = """
     'generated_modules_dictionary_files': [
       '<(blink_modules_output_dir)/app_banner/BeforeInstallPromptEventInit.cpp',
       '<(blink_modules_output_dir)/app_banner/BeforeInstallPromptEventInit.h',
@@ -480,10 +567,16 @@
       '<(blink_modules_output_dir)/serviceworkers/InstallEventInit.h',
       '<(blink_modules_output_dir)/serviceworkers/RegistrationOptions.cpp',
       '<(blink_modules_output_dir)/serviceworkers/RegistrationOptions.h',
+    """
+
+    str_speech = """
       '<(blink_modules_output_dir)/speech/SpeechRecognitionErrorInit.cpp',
       '<(blink_modules_output_dir)/speech/SpeechRecognitionErrorInit.h',
       '<(blink_modules_output_dir)/speech/SpeechRecognitionEventInit.cpp',
       '<(blink_modules_output_dir)/speech/SpeechRecognitionEventInit.h',
+    """
+
+    str_tail = """
       '<(blink_modules_output_dir)/storage/StorageEventInit.cpp',
       '<(blink_modules_output_dir)/storage/StorageEventInit.h',
       '<(blink_modules_output_dir)/vr/VRFieldOfViewInit.cpp',
@@ -499,6 +592,16 @@
       '<(blink_modules_output_dir)/websockets/CloseEventInit.cpp',
       '<(blink_modules_output_dir)/websockets/CloseEventInit.h',
     ],
+    """
+
+    if not disable_speech:
+        str = str + str_speech
+
+    return str + str_tail
+####################################end generated_modules_dictionary_files
+
+def modules_files():
+    str = """
     'modules_files': [
       '<@(extra_blink_module_files)',
       '<@(generated_modules_dictionary_files)',
@@ -1114,6 +1217,9 @@
       'serviceworkers/ServiceWorkerThread.cpp',
       'serviceworkers/ServiceWorkerThread.h',
       'serviceworkers/WaitUntilObserver.cpp',
+    """
+
+    str_speech = """
       'speech/DOMWindowSpeechSynthesis.cpp',
       'speech/DOMWindowSpeechSynthesis.h',
       'speech/SpeechGrammar.cpp',
@@ -1143,6 +1249,9 @@
       'speech/SpeechSynthesisUtterance.h',
       'speech/SpeechSynthesisVoice.cpp',
       'speech/SpeechSynthesisVoice.h',
+    """
+
+    str_tail = """
       'storage/DOMWindowStorage.cpp',
       'storage/DOMWindowStorage.h',
       'storage/DOMWindowStorageController.cpp',
@@ -1417,14 +1526,40 @@
       'websockets/WorkerWebSocketChannel.cpp',
       'websockets/WorkerWebSocketChannel.h',
     ],
+    """
+
+    if not disable_speech:
+        str = str + str_speech
+
+    return str + str_tail
+####################################end modules_files
+
+def modules_testing_dependency_idl_files():
+    str = """
     # 'partial interface' or target (right side of) 'implements'
     'modules_testing_dependency_idl_files' : [
       'geolocation/testing/InternalsGeolocation.idl',
       'navigatorcontentutils/testing/InternalsNavigatorContentUtils.idl',
       'serviceworkers/testing/InternalsServiceWorker.idl',
+    """
+
+    str_speech = """
       'speech/testing/InternalsSpeechSynthesis.idl',
+    """
+
+    str_tail = """
       'vibration/testing/InternalsVibration.idl',
     ],
+    """
+
+    if not disable_speech:
+        str = str + str_speech
+
+    return str + str_tail
+####################################end modules_testing_dependency_idl_files
+
+def modules_testing_files():
+    str = """
     'modules_testing_files': [
       'geolocation/testing/GeolocationClientMock.cpp',
       'geolocation/testing/GeolocationClientMock.h',
@@ -1436,13 +1571,29 @@
       'navigatorcontentutils/testing/NavigatorContentUtilsClientMock.h',
       'serviceworkers/testing/InternalsServiceWorker.cpp',
       'serviceworkers/testing/InternalsServiceWorker.h',
+    """
+
+    str_speech = """
       'speech/testing/InternalsSpeechSynthesis.cpp',
       'speech/testing/InternalsSpeechSynthesis.h',
       'speech/testing/PlatformSpeechSynthesizerMock.cpp',
       'speech/testing/PlatformSpeechSynthesizerMock.h',
+    """
+
+    str_tail = """
       'vibration/testing/InternalsVibration.cpp',
       'vibration/testing/InternalsVibration.h',
     ],
+    """
+
+    if not disable_speech:
+        str = str + str_speech
+
+    return str + str_tail
+####################################end modules_testing_files
+
+def modules_unittest_files():
+    str = """
     'modules_unittest_files': [
       'accessibility/AXObjectTest.cpp',
       'fetch/BodyStreamBufferTest.cpp',
@@ -1458,6 +1609,13 @@
       'websockets/DOMWebSocketTest.cpp',
       'websockets/DocumentWebSocketChannelTest.cpp',
     ],
+    """
+
+    return str
+###################################end modules_unittest_files
+
+def modules_files_inspector():
+    str = """
     'modules_files_inspector': [
       'accessibility/InspectorAccessibilityAgent.cpp',
       'accessibility/InspectorAccessibilityAgent.h',
@@ -1478,5 +1636,41 @@
       'webdatabase/InspectorDatabaseResource.cpp',
       'webdatabase/InspectorDatabaseResource.h',
     ],
+    """
+
+    return str
+###################################end modules_files_inspector
+
+def file_tail():
+    str = """
   },
 }
+    """
+    return str
+####################################
+
+def generate_modules_gypi(speech):
+    global disable_speech
+
+    disable_speech = speech
+
+    if os.path.exists('third_party/WebKit/Source/modules/modules.gypi'):
+        os.remove('third_party/WebKit/Source/modules/modules.gypi')
+
+    with open('third_party/WebKit/Source/modules/modules.gypi', 'a') as f:
+        f.write(file_header())
+        f.write(modules_idl_files())
+        f.write(modules_dependency_idl_files())
+        f.write(modules_event_idl_files())
+        f.write(modules_dictionary_idl_files())
+        f.write(generated_modules_files())
+        f.write(generated_modules_dictionary_files())
+        f.write(modules_files())
+        f.write(modules_testing_dependency_idl_files())
+        f.write(modules_testing_files())
+        f.write(modules_unittest_files())
+        f.write(modules_files_inspector())
+        f.write(file_tail())
+        print "Generate file ./third_party/WebKit/Source/modules/modules.gypi"
+
+

--- a/Source/web/AssertMatchingEnums.cpp
+++ b/Source/web/AssertMatchingEnums.cpp
@@ -63,7 +63,9 @@
 #include "modules/indexeddb/IndexedDB.h"
 #include "modules/navigatorcontentutils/NavigatorContentUtilsClient.h"
 #include "modules/quota/DeprecatedStorageQuota.h"
+#ifndef DISABLE_SPEECH
 #include "modules/speech/SpeechRecognitionError.h"
+#endif
 #include "platform/Cursor.h"
 #include "platform/FileMetadata.h"
 #include "platform/FileSystemType.h"
@@ -128,7 +130,9 @@
 #include "public/web/WebSecurityPolicy.h"
 #include "public/web/WebSerializedScriptValueVersion.h"
 #include "public/web/WebSettings.h"
+#ifndef DISABLE_SPEECH
 #include "public/web/WebSpeechRecognizerClient.h"
+#endif
 #include "public/web/WebTextAffinity.h"
 #include "public/web/WebTextCheckingResult.h"
 #include "public/web/WebTextCheckingType.h"
@@ -578,6 +582,7 @@ STATIC_ASSERT_MATCHING_ENUM(WebMediaStreamSource::ReadyStateLive, MediaStreamSou
 STATIC_ASSERT_MATCHING_ENUM(WebMediaStreamSource::ReadyStateMuted, MediaStreamSource::ReadyStateMuted);
 STATIC_ASSERT_MATCHING_ENUM(WebMediaStreamSource::ReadyStateEnded, MediaStreamSource::ReadyStateEnded);
 
+#ifndef DISABLE_SPEECH
 STATIC_ASSERT_MATCHING_ENUM(WebSpeechRecognizerClient::OtherError, SpeechRecognitionError::ErrorCodeOther);
 STATIC_ASSERT_MATCHING_ENUM(WebSpeechRecognizerClient::NoSpeechError, SpeechRecognitionError::ErrorCodeNoSpeech);
 STATIC_ASSERT_MATCHING_ENUM(WebSpeechRecognizerClient::AbortedError, SpeechRecognitionError::ErrorCodeAborted);
@@ -587,6 +592,7 @@ STATIC_ASSERT_MATCHING_ENUM(WebSpeechRecognizerClient::NotAllowedError, SpeechRe
 STATIC_ASSERT_MATCHING_ENUM(WebSpeechRecognizerClient::ServiceNotAllowedError, SpeechRecognitionError::ErrorCodeServiceNotAllowed);
 STATIC_ASSERT_MATCHING_ENUM(WebSpeechRecognizerClient::BadGrammarError, SpeechRecognitionError::ErrorCodeBadGrammar);
 STATIC_ASSERT_MATCHING_ENUM(WebSpeechRecognizerClient::LanguageNotSupportedError, SpeechRecognitionError::ErrorCodeLanguageNotSupported);
+#endif
 
 STATIC_ASSERT_MATCHING_ENUM(WebReferrerPolicyAlways, ReferrerPolicyAlways);
 STATIC_ASSERT_MATCHING_ENUM(WebReferrerPolicyDefault, ReferrerPolicyDefault);

--- a/Source/web/WebViewImpl.cpp
+++ b/Source/web/WebViewImpl.cpp
@@ -442,7 +442,9 @@ WebViewImpl::WebViewImpl(WebViewClient* client)
 
     m_page = adoptPtrWillBeNoop(new Page(pageClients));
     MediaKeysController::provideMediaKeysTo(*m_page, &m_mediaKeysClientImpl);
+#ifndef DISABLE_SPEECH
     provideSpeechRecognitionTo(*m_page, SpeechRecognitionClientProxy::create(client ? client->speechRecognizer() : 0));
+#endif
     provideNavigatorContentUtilsTo(*m_page, NavigatorContentUtilsClientImpl::create(this));
     provideContextFeaturesTo(*m_page, ContextFeaturesClientImpl::create());
     provideDatabaseClientTo(*m_page, DatabaseClientImpl::create());

--- a/Source/web/web.gyp
+++ b/Source/web/web.gyp
@@ -93,6 +93,13 @@
                     '<@(web_files_inspector)',
                   ],
                 }],
+
+                ['disable_speech==1', {
+                    'sources!': [
+                        '<@(web_files_speech)',
+                    ],
+                }],
+
                 ['component=="shared_library"', {
                     'dependencies': [
                         '../wtf/wtf_tests.gyp:wtf_unittest_helpers',

--- a/Source/web/web.gypi
+++ b/Source/web/web.gypi
@@ -6,6 +6,15 @@
       'WebDevToolsFrontendImpl.cpp',
       'WebDevToolsFrontendImpl.h',
     ],
+
+    'web_files_speech': [
+      'SpeechRecognitionClientProxy.cpp',
+      'SpeechRecognitionClientProxy.h',
+      'WebSpeechGrammar.cpp',
+      'WebSpeechRecognitionHandle.cpp',
+      'WebSpeechRecognitionResult.cpp',
+    ],
+
     'web_files': [
       'AssertMatchingEnums.cpp',
       'AssociatedURLLoader.cpp',


### PR DESCRIPTION
To disable Web Speech
 
With build flag "-Ddisable_speech=1" binary size is reduced by 0.11M.
    
 Due to syntax limitation of gyp, import 'modules_gypi_generator.py' to synthesize the 'third_party/WebKit/Source/modules/modules.gypi'  directly to exclude the disabled '*.idl' files.

Other modules in './third_party/WebKit/Sources/modules' can be disable by the same way.