### PR TITLE
To disable WebVideo

### DIFF
--- a/Source/core/html/HTMLMediaElement.cpp
+++ b/Source/core/html/HTMLMediaElement.cpp
@@ -3437,7 +3437,9 @@ void HTMLMediaElement::createMediaPlayer()
 
     closeMediaSource();
 
+#ifndef DISABLE_WEB_VIDEO
     m_player = MediaPlayer::create(this);
+#endif
 
     // We haven't yet found out if any remote routes are available.
     m_remoteRoutesAvailable = false;

--- a/Source/web/WebKit.cpp
+++ b/Source/web/WebKit.cpp
@@ -188,7 +188,9 @@ void initializeWithoutV8(Platform* platform)
 
     setIndexedDBClientCreateFunction(IndexedDBClientImpl::create);
 
+#ifndef DISABLE_WEB_VIDEO
     MediaPlayer::setMediaEngineCreateFunction(WebMediaPlayerClientImpl::create);
+#endif
 }
 
 void shutdown()

--- a/Source/web/web.gyp
+++ b/Source/web/web.gyp
@@ -100,6 +100,12 @@
                     ],
                 }],
 
+                ['disable_web_video==1', {
+                  'sources!': [
+                    '<@(web_files_web_video)',
+                  ],
+                }],
+
                 ['component=="shared_library"', {
                     'dependencies': [
                         '../wtf/wtf_tests.gyp:wtf_unittest_helpers',

--- a/Source/web/web.gypi
+++ b/Source/web/web.gypi
@@ -280,6 +280,10 @@
       'painting/PaintAggregator.h',
       'win/WebFontRendering.cpp',
     ],
+    'web_files_web_video': [
+      'WebMediaPlayerClientImpl.cpp',
+      'WebMediaPlayerClientImpl.h',
+    ],
     'web_unittest_files': [
       'ExternalPopupMenuTest.cpp',
       'PageOverlayTest.cpp',


### PR DESCRIPTION
With flag "-Ddisable_web_video=1" the size is reduced by 180K.

The 'DISABLE_WEB_VIDEO' is defined in 'xwalk/build/common.js'
