### PR TITLE
Bug fix for minimum resources.

### DIFF
--- a/public/blink_resources.grd
+++ b/public/blink_resources.grd
@@ -9,9 +9,7 @@
   </outputs>
   <release seq="1">
     <includes>
-      <if expr="not pp_ifdef('use_minimum_resources')">
-        <include name="IDR_UASTYLE_HTML_CSS" file="../Source/core/css/html.css" type="BINDATA"/>
-      </if>
+      <include name="IDR_UASTYLE_HTML_CSS" file="../Source/core/css/html.css" type="BINDATA"/>
       <include name="IDR_UASTYLE_QUIRKS_CSS" file="../Source/core/css/quirks.css" type="BINDATA"/>
       <include name="IDR_UASTYLE_VIEW_SOURCE_CSS" file="../Source/core/css/view-source.css" type="BINDATA"/>
       <include name="IDR_UASTYLE_THEME_CHROMIUM_CSS" file="../Source/core/css/themeChromium.css" type="BINDATA"/>


### PR DESCRIPTION
For crosswalk-lite-10, a macro named IDR_UASTYLE_HTML_CSS generate in
./gen/blink/public/resources/grit/blink_resources.h,
whether the option use_minimum_resources is enable or disable.
In crosswalk-lite, IDR_UASTYLE_HTML_CSS would not generate if we disable
use_minimum_resources, so we need add it back to avoid the compiling
error.

Simply remove IDR_UASTYLE_HTML_CSS and html.css will cause the layout mess
up.