### PR TITLE
[XDK] Add in-depth allocation tracker

### DIFF
--- a/Source/core/inspector/InspectorHeapProfilerAgent.cpp
+++ b/Source/core/inspector/InspectorHeapProfilerAgent.cpp
@@ -186,6 +186,20 @@ private:
     Timer<HeapStatsUpdateTask> m_timer;
 };
 
+
+class InspectorHeapProfilerAgent::HeapXDKUpdateTask final : public NoBaseWillBeGarbageCollectedFinalized<InspectorHeapProfilerAgent::HeapXDKUpdateTask>{
+public:
+    HeapXDKUpdateTask(InspectorHeapProfilerAgent*);
+    void startTimer(float sav);
+    void resetTimer() { m_timer.stop(); }
+    void onTimer(Timer<HeapXDKUpdateTask>*);
+    
+private:
+    InspectorHeapProfilerAgent* m_heapProfilerAgent;
+    Timer<HeapXDKUpdateTask> m_timer;
+};
+
+
 PassOwnPtrWillBeRawPtr<InspectorHeapProfilerAgent> InspectorHeapProfilerAgent::create(v8::Isolate* isolate, InjectedScriptManager* injectedScriptManager)
 {
     return adoptPtrWillBeNoop(new InspectorHeapProfilerAgent(isolate, injectedScriptManager));
@@ -384,6 +398,119 @@ DEFINE_TRACE(InspectorHeapProfilerAgent)
     visitor->trace(m_injectedScriptManager);
     visitor->trace(m_heapStatsUpdateTask);
     InspectorBaseAgent::trace(visitor);
+}
+
+static PassRefPtr<TypeBuilder::HeapProfiler::HeapEventXDK> createHeapProfileXDK(const HeapProfileXDK& heapProfileXDK)
+{
+    RefPtr<TypeBuilder::HeapProfiler::HeapEventXDK> profile = TypeBuilder::HeapProfiler::HeapEventXDK::create()
+        .setDuration(heapProfileXDK.getDuration())
+        .setSymbols(heapProfileXDK.getSymbols())
+        .setFrames(heapProfileXDK.getFrames())
+        .setTypes(heapProfileXDK.getTypes())
+        .setChunks(heapProfileXDK.getChunks())
+        .setRetentions(heapProfileXDK.getRetentions());
+    return profile.release();
+}
+
+InspectorHeapProfilerAgent::HeapXDKUpdateTask::HeapXDKUpdateTask(InspectorHeapProfilerAgent* heapProfilerAgent)
+    : m_heapProfilerAgent(heapProfilerAgent)
+    , m_timer(this, &HeapXDKUpdateTask::onTimer)
+{
+}
+
+void InspectorHeapProfilerAgent::HeapXDKUpdateTask::onTimer(Timer<HeapXDKUpdateTask>*)
+{
+    // The timer is stopped on m_heapProfilerAgent destruction,
+    // so this method will never be called after m_heapProfilerAgent has been destroyed.
+    m_heapProfilerAgent->requestHeapXDKUpdate();
+}
+
+void InspectorHeapProfilerAgent::HeapXDKUpdateTask::startTimer(float sav)
+{
+    ASSERT(!m_timer.isActive());
+    m_timer.startRepeating(sav, FROM_HERE);
+}
+
+void InspectorHeapProfilerAgent::startTrackingHeapXDK(ErrorString*,
+                                                      const int* stack_depth,
+                                                      const int* sav,
+                                                      const bool* retentions)
+{
+    m_state->setBoolean(HeapProfilerAgentState::heapObjectsTrackingEnabled, true);
+  
+    // inline of startTrackingHeapObjectsInternal(allocationTrackingEnabled);
+    if (m_heapXDKUpdateTask)
+        return;
+    int stackDepth = 8;
+    if (stack_depth) {
+      stackDepth = *stack_depth;
+    }
+    float sav_timer = 1;
+    if (sav) {
+      sav_timer = (float)*sav / 1000.;
+    }
+    bool needRetentions = retentions && *retentions;
+    InspectorProfilerAgent::startTrackingHeapObjectsXDK(stackDepth, needRetentions);
+    m_heapXDKUpdateTask = adoptPtr(new HeapXDKUpdateTask(this));
+    m_heapXDKUpdateTask->startTimer(sav_timer);
+}
+
+class InspectorHeapProfilerAgent::HeapXDKStream final : public InspectorProfilerAgent::OutputStream{
+public:
+    HeapXDKStream(InspectorHeapProfilerAgent* heapProfilerAgent)
+        : m_heapProfilerAgent(heapProfilerAgent)
+    {
+    }
+
+    virtual void write(const uint32_t* chunk, const int size){}
+    virtual void write(const char* symbols, int symbolsSize,
+                       const char* frames, int framesSize,
+                       const char* types, int typesSize,
+                       const char* chunks, int chunksSize,
+                       const char* retentions, int retentionsSize) override
+    {
+        m_heapProfilerAgent->pushHeapXDKUpdate(symbols, symbolsSize, frames, framesSize,
+        types, typesSize, chunks, chunksSize,
+        retentions, retentionsSize);
+    }
+private:
+    InspectorHeapProfilerAgent* m_heapProfilerAgent;
+};
+
+void InspectorHeapProfilerAgent::requestHeapXDKUpdate()
+{
+    if (!frontend())
+        return;
+    HeapXDKStream stream(this);
+    InspectorProfilerAgent::requestHeapXDKUpdate(&stream);
+}
+
+void InspectorHeapProfilerAgent::stopTrackingHeapXDK(ErrorString* error, RefPtr<TypeBuilder::HeapProfiler::HeapEventXDK>& profile)
+{
+    if (!m_heapXDKUpdateTask) {
+        *error = "Heap object tracking is not started.";
+        return;
+    }
+
+    RefPtr<HeapProfileXDK> heapProfileXDK = InspectorProfilerAgent::stopTrackingHeapObjectsXDK();
+    profile = createHeapProfileXDK(*heapProfileXDK);
+
+    m_heapXDKUpdateTask->resetTimer();
+    m_heapXDKUpdateTask.clear();
+    m_state->setBoolean(HeapProfilerAgentState::heapObjectsTrackingEnabled, false);
+
+}
+void InspectorHeapProfilerAgent::pushHeapXDKUpdate(const char* symbols, int symbolsSize,
+                                        const char* frames, int framesSize,
+                                        const char* types, int typesSize,
+                                        const char* chunks, int chunksSize,
+                                        const char* retentions, int retentionsSize)
+{
+    if (!frontend())
+         return;
+    frontend()->heapXDKUpdate(String(symbols, symbolsSize), String(frames, framesSize),
+                              String(types, typesSize), String(chunks, chunksSize),
+                              String(retentions, retentionsSize));
 }
 
 } // namespace blink

--- a/Source/core/inspector/InspectorHeapProfilerAgent.h
+++ b/Source/core/inspector/InspectorHeapProfilerAgent.h
@@ -40,6 +40,7 @@
 #include "wtf/OwnPtr.h"
 #include "wtf/PassOwnPtr.h"
 #include "wtf/text/WTFString.h"
+#include "core/inspector/InspectorProfilerAgent.h"
 
 namespace v8 {
 class Isolate;
@@ -75,8 +76,14 @@ public:
     void addInspectedHeapObject(ErrorString*, const String& inspectedHeapObjectId) override;
     void getHeapObjectId(ErrorString*, const String& objectId, String* heapSnapshotObjectId) override;
 
+    void startTrackingHeapXDK(ErrorString*, const int* stack_depth, const int* sav, const bool* retentions) override;
+    void stopTrackingHeapXDK(ErrorString*, RefPtr<TypeBuilder::HeapProfiler::HeapEventXDK>&) override;
+
 private:
     class HeapStatsUpdateTask;
+
+    class HeapXDKStream;
+    class HeapXDKUpdateTask;
 
     InspectorHeapProfilerAgent(v8::Isolate*, InjectedScriptManager*);
 
@@ -85,9 +92,17 @@ private:
     void startTrackingHeapObjectsInternal(bool trackAllocations);
     void stopTrackingHeapObjectsInternal();
 
+    void requestHeapXDKUpdate();
+    void pushHeapXDKUpdate(const char* symbols, int symbolsSize,
+                           const char* frames, int framesSize,
+                           const char* types, int typesSize,
+                           const char* chunks, int chunksSize,
+                           const char* retentions, int retentionsSize);
+
     v8::Isolate* m_isolate;
     RawPtrWillBeMember<InjectedScriptManager> m_injectedScriptManager;
     OwnPtrWillBeMember<HeapStatsUpdateTask> m_heapStatsUpdateTask;
+    OwnPtrWillBeMember<HeapXDKUpdateTask> m_heapXDKUpdateTask;
 };
 
 } // namespace blink

--- a/Source/core/inspector/InspectorProfilerAgent.cpp
+++ b/Source/core/inspector/InspectorProfilerAgent.cpp
@@ -93,6 +93,7 @@ PassRefPtr<TypeBuilder::Profiler::CPUProfileNode> buildInspectorObjectFor(const 
         .setColumnNumber(node->GetColumnNumber())
         .setHitCount(node->GetHitCount())
         .setCallUID(node->GetCallUid())
+        .setStackEntryLine(node->GetSrcLine())
         .setChildren(children.release())
         .setPositionTicks(positionTicks.release())
         .setDeoptReason(node->GetBailoutReason())
@@ -369,6 +370,93 @@ DEFINE_TRACE(InspectorProfilerAgent)
     visitor->trace(m_injectedScriptManager);
     visitor->trace(m_overlay);
     InspectorBaseAgent::trace(visitor);
+}
+
+String HeapProfileXDK::getSymbols() const
+{
+    v8::HandleScope handleScope(m_isolate);
+    return toCoreString(v8AtomicString(m_isolate, m_event->getSymbols()));
+}
+
+String HeapProfileXDK::getFrames() const
+{
+    v8::HandleScope handleScope(m_isolate);
+    return toCoreString(v8AtomicString(m_isolate, m_event->getFrames()));
+}
+
+String HeapProfileXDK::getTypes() const
+{
+    v8::HandleScope handleScope(m_isolate);
+    return toCoreString(v8AtomicString(m_isolate, m_event->getTypes()));
+}
+
+String HeapProfileXDK::getChunks() const
+{
+    v8::HandleScope handleScope(m_isolate);
+    return toCoreString(v8AtomicString(m_isolate, m_event->getChunks()));
+}
+
+int HeapProfileXDK::getDuration() const
+{
+    return (int)m_event->getDuration();
+}
+
+String HeapProfileXDK::getRetentions() const
+{
+    v8::HandleScope handleScope(m_isolate);
+    return toCoreString(v8AtomicString(m_isolate, m_event->getRetentions()));
+}
+
+namespace {
+
+class HeapXDKStream : public v8::OutputStream {
+public:
+    HeapXDKStream(InspectorProfilerAgent::OutputStream* stream) : m_stream(stream) { }
+    virtual void EndOfStream() override { }
+
+    virtual WriteResult WriteAsciiChunk(char* data, int size) override
+    {
+        ASSERT(false);
+        return kAbort;
+    }
+
+    virtual WriteResult WriteHeapXDKChunk(const char* symbols, size_t symbolsSize,
+                                          const char* frames, size_t framesSize,
+                                          const char* types, size_t typesSize,
+                                          const char* chunks, size_t chunksSize,
+                                          const char* retentions,
+                                          size_t retentionSize) override
+    {
+        m_stream->write(symbols, symbolsSize, frames, framesSize,
+            types, typesSize, chunks, chunksSize,
+            retentions, retentionSize);
+        return kContinue;
+    }
+
+private:
+    InspectorProfilerAgent::OutputStream* m_stream;
+};
+
+}
+
+void InspectorProfilerAgent::requestHeapXDKUpdate(InspectorProfilerAgent::OutputStream* stream)
+{
+    HeapXDKStream heapXDKStream(stream);
+    v8::Isolate::GetCurrent()->GetHeapProfiler()->GetHeapXDKStats(
+        &heapXDKStream);
+}
+
+void InspectorProfilerAgent::startTrackingHeapObjectsXDK(int stackDepth, bool retentions)
+{
+    v8::Isolate::GetCurrent()->GetHeapProfiler()->StartTrackingHeapObjectsXDK(
+        stackDepth, retentions);
+}
+
+PassRefPtr<HeapProfileXDK> InspectorProfilerAgent::stopTrackingHeapObjectsXDK()
+{
+    return HeapProfileXDK::create(
+        v8::Isolate::GetCurrent()
+            ->GetHeapProfiler()->StopTrackingHeapObjectsXDK(), v8::Isolate::GetCurrent());
 }
 
 } // namespace blink

--- a/Source/core/inspector/InspectorProfilerAgent.h
+++ b/Source/core/inspector/InspectorProfilerAgent.h
@@ -38,6 +38,7 @@
 #include "wtf/Noncopyable.h"
 #include "wtf/PassOwnPtr.h"
 #include "wtf/text/WTFString.h"
+#include <v8-profiler.h>
 
 namespace v8 {
 class CpuProfile;
@@ -52,6 +53,31 @@ class InspectorOverlay;
 
 typedef String ErrorString;
 
+class HeapProfileXDK final : public RefCountedWillBeGarbageCollectedFinalized<HeapProfileXDK> {
+public:
+    static PassRefPtrWillBeRawPtr<HeapProfileXDK> create(v8::HeapEventXDK* event, v8::Isolate* isolate)
+    {
+        return adoptRefWillBeNoop(new HeapProfileXDK(event, isolate));
+    }
+
+    String getSymbols() const;
+    String getFrames() const;
+    String getTypes() const;
+    String getChunks() const;
+    String getRetentions() const;
+    int getDuration() const;
+
+private:
+    HeapProfileXDK(v8::HeapEventXDK* event, v8::Isolate* isolate)
+      : m_event(event),
+        m_isolate(isolate)
+    {
+    }
+
+    v8::HeapEventXDK* m_event;
+    v8::Isolate* m_isolate;
+};
+
 class CORE_EXPORT InspectorProfilerAgent final : public InspectorBaseAgent<InspectorProfilerAgent, InspectorFrontend::Profiler>, public InspectorBackendDispatcher::ProfilerCommandHandler {
     WTF_MAKE_NONCOPYABLE(InspectorProfilerAgent);
     WTF_MAKE_FAST_ALLOCATED_WILL_BE_REMOVED(InspectorProfilerAgent);
@@ -59,6 +85,17 @@ public:
     static PassOwnPtrWillBeRawPtr<InspectorProfilerAgent> create(v8::Isolate*, InjectedScriptManager*, InspectorOverlay*);
     ~InspectorProfilerAgent() override;
     DECLARE_VIRTUAL_TRACE();
+
+    class OutputStream {
+    public:
+      virtual ~OutputStream() { }
+      virtual void write(const uint32_t* chunk, const int size) = 0;
+      virtual void write(const char* symbols, int symbolsSize,
+                         const char* frames, int framesSize,
+                         const char* types, int typesSize,
+                         const char* chunks, int chunksSize,
+                         const char* retentions, int retentionsSize) { };
+    };
 
     void consoleProfile(ExecutionContext*, const String& title);
     void consoleProfileEnd(const String& title);
@@ -75,6 +112,10 @@ public:
     void didProcessTask();
     void willEnterNestedRunLoop();
     void didLeaveNestedRunLoop();
+
+    static void startTrackingHeapObjectsXDK(int stackDepth, bool retentions);
+    static PassRefPtr<HeapProfileXDK> stopTrackingHeapObjectsXDK();
+    static void requestHeapXDKUpdate(OutputStream*);
 
 private:
     InspectorProfilerAgent(v8::Isolate*, InjectedScriptManager*, InspectorOverlay*);

--- a/Source/devtools/protocol.json
+++ b/Source/devtools/protocol.json
@@ -3994,6 +3994,7 @@
                     { "name": "columnNumber", "type": "integer", "description": "1-based column number of the function start position." },
                     { "name": "hitCount", "type": "integer", "description": "Number of samples where this node was on top of the call stack." },
                     { "name": "callUID", "type": "number", "description": "Call UID." },
+                    { "name": "stackEntryLine", "type": "integer", "description": "Hit line for entry in stack." },
                     { "name": "children", "type": "array", "items": { "$ref": "CPUProfileNode" }, "description": "Child nodes." },
                     { "name": "deoptReason", "type": "string", "description": "The reason of being not optimized. The function may be deoptimized or marked as don't optimize."},
                     { "name": "id", "type": "integer", "description": "Unique id of the node." },
@@ -4076,7 +4077,20 @@
                 "id": "HeapSnapshotObjectId",
                 "type": "string",
                 "description": "Heap snapshot object id."
-            }
+            },
+            {
+                "id": "HeapEventXDK",
+                "type": "object",
+                "description": "",
+                "properties": [
+                    { "name": "duration", "type": "integer" },
+                    { "name": "symbols", "type": "string" },
+                    { "name": "frames", "type": "string" },
+                    { "name": "types", "type": "string" },
+                    { "name": "chunks", "type": "string" },
+		                { "name": "retentions", "type": "string" }
+                ]
+             }
         ],
         "commands": [
             {
@@ -4097,6 +4111,20 @@
                     { "name": "reportProgress", "type": "boolean", "optional": true, "description": "If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken when the tracking is stopped." }
                 ]
 
+            },
+            {
+                "name": "startTrackingHeapXDK",
+                "parameters": [
+                    { "name": "stack_depth", "type": "integer", "optional": true },
+                    { "name": "sav", "type": "integer", "optional": true },
+                    { "name": "retentions", "type": "boolean", "optional": true }
+                ]
+            },
+            {
+                "name": "stopTrackingHeapXDK",
+                "returns": [
+                    { "name": "profileXDK", "$ref": "HeapEventXDK", "description": "Recorded profile." }
+                ]
             },
             {
                 "name": "takeHeapSnapshot",
@@ -4166,7 +4194,17 @@
                 "parameters": [
                     { "name": "statsUpdate", "type": "array", "items": { "type": "integer" }, "description": "An array of triplets. Each triplet describes a fragment. The first integer is the fragment index, the second integer is a total count of objects for the fragment, the third integer is a total size of the objects for the fragment."}
                 ]
-            }
+            },
+	          {
+                "name": "heapXDKUpdate",
+                "parameters": [
+		                { "name": "symbols", "type": "string" },
+		                { "name": "frames", "type": "string" },
+		                { "name": "types", "type": "string" },
+		                { "name": "chunks", "type": "string" },
+		                { "name": "retentions", "type": "string" }
+		            ]
+	          }
         ]
     },
     {


### PR DESCRIPTION
This patch includes in-depth allocation tracker and extention of protocol.json by stackEntryLine that is used for total time annotations in CPU profiling.

Details of HeapProfiler: Three new commands were added by analogy with Chrome DevTools
allocation tracker. Start/Stop and Event which is sent by timer.
Command stopTrackingHeapXDK accepts three parameters: stack depth for unwinding,
Sample After Value - period of timer and a flag to collect retention
information or not. Event sends to the host currently collected data about
symbols/callstack/objects. Command stopTrackingHeapXDK returns the final
info witch is similar to Event passed format with one more parameter: duration
of the collection.

Basing on this info consumer can build allocation call tree for any period of
time, annotate source by self and total allocation mertics and annotate
allocation call tree by the objects, which retain other objects in the memory.

BUG=XWALK-5109
