### PR TITLE
Remove the message output of "modules_gypi_generator.py"

### DIFF
--- a/Source/modules/modules_gypi_generator.py
+++ b/Source/modules/modules_gypi_generator.py
@@ -1794,6 +1794,5 @@ def generate_modules_gypi(speech, notifications):
         f.write(modules_unittest_files())
         f.write(modules_files_inspector())
         f.write(file_tail())
-        print "Generate file ./third_party/WebKit/Source/modules/modules.gypi"
 
 


### PR DESCRIPTION
To avoid to make user confused, as heke suggested.
